### PR TITLE
feat: context-aware Gemini reviews (ingest PR comments via PyGithub) + Python 3.12, docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,42 @@
 # gemini-code-review-action
-A container GitHub Action to review a pull request by Gemini AI.
+GitHub Action that uses Google Gemini to automatically review Pull Requests.
 
-If the size of a pull request is over the maximum chunk size of the Gemini API, the Action will split the pull request into multiple chunks and generate review comments for each chunk.
-And then the Action summarizes the review comments and posts a review comment to the pull request.
+If the diff exceeds the model's context window, the Action splits it into chunks and requests feedback per chunk, then produces a final summary and posts a single PR review. The Action also reads existing PR discussion (general comments, inline review comments, and past review summaries) and feeds them to Gemini as context so the review considers prior feedback.
 
 ## Pre-requisites
-We have to set a GitHub Actions secret `GEMINI_API_KEY` to use the Gemini API so that we securely pass it to the Action.
+- Set a repository secret `GEMINI_API_KEY` with your Gemini API key.
+  - Get an API key: [GET MY API KEY](https://makersuite.google.com/app/apikey)
+- The workflow should grant `contents: read` and `pull-requests: write` permissions (see example below).
 
 ## Inputs
 
-- `gemini_api_key`: The Gemini API key to access the Gemini API [(GET MY API KEY)](https://makersuite.google.com/app/apikey).
-- `github_token`: The GitHub token to access the GitHub API (You do not need to generate this Token!).
-- `github_repository`: The GitHub repository to post a review comment.
-- `github_pull_request_number`: The GitHub pull request number to post a review comment.
-- `git_commit_hash`: The git commit hash to post a review comment.
-- `pull_request_diff_file`: The path to the git diff of the pull request to generate a review comment.
-- `pull_request_diff_chunk_size`: The chunk size of the diff of the pull request to generate a review comment.
-- `extra_prompt`: The extra prompt to generate a review comment.
-- `model`: The model to generate a review comment. We can use a model which is available.
-- `log_level`: The log level to print logs.
+- `gemini_api_key` (required): Gemini API key (secret recommended).
+- `github_token` (required): GitHub token. Use the default `${{ secrets.GITHUB_TOKEN }}`.
+- `github_repository` (required): Target repository (defaults to `${{ github.repository }}`).
+- `github_pull_request_number` (required): PR number (defaults to `${{ github.event.pull_request.number }}`).
+- `git_commit_hash` (required): PR head SHA (defaults to `${{ github.event.pull_request.head.sha }}`).
+- `model` (required): Gemini model name (e.g., `gemini-1.5-pro-latest`).
+- `extra_prompt` (optional): Additional system guidance to steer the review.
+- `temperature` (optional): Sampling temperature.
+- `top_p` (optional): Nucleus sampling.
+- `pull_request_diff_file` (required): Path to the PR diff file to review.
+- `pull_request_chunk_size` (optional): Diff chunk size to fit model limits.
+- `log_level` (optional): Logging level (e.g., `INFO`, `DEBUG`).
+
+## Features
+- Splits large diffs and aggregates per-chunk analysis.
+- Summarizes into a single review comment posted to the PR.
+- Reads existing PR comments and reviews using PyGithub and injects them into the AI context so prior feedback is respected.
+- Configurable prompt, model, and chunk size.
 
 As you might know, a model of Gemini has limitation of the maximum number of input tokens.
 So we have to split the diff of a pull request into multiple chunks, if the size of the diff is over the limitation.
 We can tune the chunk size based on the model we use.
 
 ## Example usage
-Here is an example to use the Action to review a pull request of the repository.
-The actual file is located at [`.github/workflows/ai-code-review.yml`](.github/workflows/ai-code-review.yml).
-We set `extra_prompt` to `Sempre responda em português brasileiro!`.
-We aim to make GPT review a pull request from a point of view of a Python developer.
+The workflow below writes the PR diff to a file and passes its path to the Action. The Action will also fetch PR comments automatically via the provided `github_token` and include them in the review context.
 
-As a result of an execution of the Action, the Action posts a review comment to the pull request like the following image.
+As a result, a single consolidated review is posted to the PR.
 ![An example comment of the code review](./docs/images/example.png)
 
 ```yaml
@@ -39,7 +45,7 @@ name: "Code Review by Gemini AI"
 on:
   pull_request:
 env:
-  GEMINI_MODEL: "gemini-1.5-pro-latest"
+  GEMINI_MODEL: "gemini-2.5-flash"
 
 jobs:
   review:
@@ -48,7 +54,7 @@ jobs:
       contents: read
       pull-requests: write
     env:
-      PR_DIFF_PATH: "pull-request.diff"
+      PR_DIFF_PATH: pull-request.diff
     steps:
       - uses: actions/checkout@v4
       - name: "Get diff of the pull request"
@@ -71,11 +77,30 @@ jobs:
           github_repository: ${{ github.repository }}
           github_pull_request_number: ${{ github.event.pull_request.number }}
           git_commit_hash: ${{ github.event.pull_request.head.sha }}
-          model: "gemini-1.5-pro-latest"
-          pull_request_diff: |-
-            ${{ steps.get_diff.outputs.pull_request_diff }}
+          model: gemini-2.5-flash
+          pull_request_diff_file: ${{ env.PR_DIFF_PATH }}
           pull_request_chunk_size: "100000"
-          extra_prompt: |-
-            Always response in English
-          log_level: "DEBUG"
+          extra_prompt: |
+            Please review as a senior Python and security engineer. Be concise and actionable.
+          log_level: INFO
 ```
+
+## How it works
+1. The workflow produces a unified diff file of the PR and provides it to the Action.
+2. The Action loads the diff, splits it into chunks according to `pull_request_chunk_size`.
+3. For each chunk, it sends:
+   - A review instruction prompt, then the diff chunk,
+   - Then a message containing the existing PR comments and reviews (via PyGithub),
+   - Then asks Gemini to produce the final feedback for that chunk.
+4. The Action summarizes the chunk-level feedback and posts a single review on the PR.
+
+## Permissions and security
+- Uses the default `GITHUB_TOKEN` to read PR metadata and post reviews.
+- Requires `pull-requests: write` to create a PR review.
+- Keep your `GEMINI_API_KEY` in repository secrets; never commit it.
+
+## Local testing
+Set the `LOCAL` environment variable to any value to prevent posting comments and log the review output instead.
+
+## Notes
+- This Action fetches PR comments using [PyGithub](https://github.com/PyGithub/PyGithub) and includes them in the model context to avoid redundant feedback and align with ongoing discussion.


### PR DESCRIPTION
### Pull Request Description
- **Why**
  - Reviews lacked context from ongoing PR discussions, causing duplicated or conflicting feedback. This adds PR comments as first-class context to improve review quality.

- **What changed**
  - **PR comments ingestion**
    - Fetches existing discussion using PyGithub: issue comments, inline review comments, and prior review summaries.
    - Sends comments to Gemini right after each diff chunk and before requesting the final output.
  - **Engine**
    - Conversation flow per chunk: send diff → send PR comments context → request final review.
    - `AiReviewConfig` extended with `comments_text`; improved logging (chunk count, comments payload size).
    - Narrowed exception handling (uses `GithubException`).
  - **Build**
    - Base image updated to `python:3.12-slim`.
    - Dependencies: added `PyGithub==2.7.0`.
  - **Docs**
    - `README.md` updated with features, permissions, “How it works,” local testing guidance.
    - Example workflow updated to use `pull_request_diff_file` and model `gemini-2.5-flash` (configurable).

- **Behavior**
  - For large diffs, chunks are processed independently, with PR comments injected as context per chunk.
  - Summarizes chunk outputs into one review comment posted to the PR.
  - Skips posting when `LOCAL` is set and logs the review instead.

- **Breaking changes**
  - Use `pull_request_diff_file` instead of the old `pull_request_diff` string input.

- **Migration**
  - Save PR diff to a file (e.g., `pull-request.diff`) and pass it via `pull_request_diff_file`.
  - Ensure workflow permissions include `pull-requests: write`.
  - Optionally set `model` (README example uses `gemini-2.5-flash`).

- **Risks/Notes**
  - More tokens used due to added comments context; tune `pull_request_chunk_size`, `temperature`, and `top_p` as needed.
  - Requires default `GITHUB_TOKEN` to read PR data and post reviews.

- **Testing**
  - Run the workflow on a PR with existing discussion; verify the final review references prior comments and proposes consolidated feedback.
  - Toggle `LOCAL` to validate output without posting.

- **Security/Permissions**
  - `GEMINI_API_KEY` must be stored as a secret.
  - Uses `GITHUB_TOKEN` with `pull-requests: write`.

- **Reference**
  - PyGithub: https://github.com/PyGithub/PyGithub

- **Files of interest**
  - `entrypoint.py`, `requirements.txt`, `Dockerfile`, `README.md`