### PR TITLE
Enhance error handling in entrypoint.py for fetching PR comments and …

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ jobs:
 ## Permissions and security
 - Uses the default `GITHUB_TOKEN` to read PR metadata and post reviews.
 - Requires `pull-requests: write` to create a PR review.
+- Optional but recommended: `issues: read` to allow fetching general PR discussion comments.
+- If `issues: read` or other permissions are unavailable, the Action will skip the unavailable comment types and proceed with the rest.
 - Keep your `GEMINI_API_KEY` in repository secrets; never commit it.
 
 ## Local testing

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -110,13 +110,41 @@ def get_all_pr_comments_text(
         pr = repo.get_pull(pull_request_number)
 
         # Issue comments (general discussion on the PR as an issue)
-        issue_comments = list(pr.as_issue().get_comments())
+        try:
+            issue_comments = list(pr.as_issue().get_comments())
+        except GithubException as exc:
+            # Common when GITHUB_TOKEN lacks `issues: read` permission on some repos
+            if getattr(exc, "status", None) == 403:
+                logger.warning(
+                    "Skipping issue comments due to insufficient permissions (issues: read)."
+                )
+                issue_comments = []
+            else:
+                raise
 
         # Review comments (inline file comments)
-        review_comments = list(pr.get_comments())
+        try:
+            review_comments = list(pr.get_comments())
+        except GithubException as exc:
+            if getattr(exc, "status", None) == 403:
+                logger.warning(
+                    "Skipping PR review comments due to insufficient permissions."
+                )
+                review_comments = []
+            else:
+                raise
 
         # Reviews (summary reviews, states like APPROVED/CHANGES_REQUESTED)
-        reviews = list(pr.get_reviews())
+        try:
+            reviews = list(pr.get_reviews())
+        except GithubException as exc:
+            if getattr(exc, "status", None) == 403:
+                logger.warning(
+                    "Skipping PR reviews list due to insufficient permissions."
+                )
+                reviews = []
+            else:
+                raise
 
         lines: List[str] = []
         if issue_comments:


### PR DESCRIPTION
This pull request improves the handling of GitHub permissions for fetching pull request comments, making the workflow more robust when some permissions are missing. It also updates the documentation to clarify recommended permissions and the behavior when permissions are unavailable.

**Permissions handling improvements:**

* Gracefully handles missing `issues: read` permission by catching `GithubException` and skipping issue comments, logging a warning instead of failing. (`entrypoint.py`)
* Similarly, catches permission errors when fetching review comments and reviews, skipping them and logging warnings if the required permissions are not present. (`entrypoint.py`)

**Documentation updates:**

* Updates the `README.md` to recommend the `issues: read` permission and explains that the Action will skip unavailable comment types if permissions are missing, proceeding with the rest of the workflow. (`README.md`)…reviews. Added exception handling for Github API permission errors, logging warnings when permissions are insufficient. Updated README.md to reflect the need for `issues: read` permission for fetching PR discussion comments.