### PR TITLE
chore: migrate from deprecated google-generativeai to google-genai SDK

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,6 @@ loguru==0.7.0
 
 requests==2.32.2
 
-google-generativeai==0.8.6
+google-genai
 PyGithub==2.7.0
 zipp>=3.19.1 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/src/gemini_client.py
+++ b/src/gemini_client.py
@@ -13,8 +13,7 @@ import os
 import time
 from typing import List, Optional
 
-import google.generativeai as genai
-from google.api_core import exceptions as google_exceptions
+from google.genai import errors, types
 from loguru import logger
 
 from src.config import AiReviewConfig
@@ -26,13 +25,13 @@ from src.utils import (_extract_model_text, _safe_str, calculate_char_budget,
 DEFAULT_TOKEN_LIMIT = 1_000_000
 
 
-def get_model_context_limit(model_name: str) -> int:
-    """Query the model's input_token_limit via genai.get_model().
+def get_model_context_limit(client, model_name: str) -> int:
+    """Query the model's input_token_limit via client.models.get().
 
     Falls back to DEFAULT_TOKEN_LIMIT (1_000_000) on any failure.
     """
     try:
-        model_info = genai.get_model(model_name)
+        model_info = client.models.get(model=model_name)
         limit = getattr(model_info, "input_token_limit", None)
         if limit is not None and limit > 0:
             return int(limit)
@@ -41,7 +40,7 @@ def get_model_context_limit(model_name: str) -> int:
     return DEFAULT_TOKEN_LIMIT
 
 
-def get_review(config: AiReviewConfig) -> tuple:
+def get_review(client, config: AiReviewConfig) -> tuple:
     """Get a review from Gemini for the given diff configuration."""
     model = config["model"]
     diff = config["diff"]
@@ -53,39 +52,28 @@ def get_review(config: AiReviewConfig) -> tuple:
     top_k = config.get("top_k", 0)
     max_output_tokens = config.get("max_output_tokens", 8192)
     review_prompt = get_review_prompt(extra_prompt=extra_prompt)
-    generation_config = {
-        "temperature": temperature,
-        "top_p": top_p,
-        "top_k": top_k,
-        "max_output_tokens": max_output_tokens,
-        "response_mime_type": "application/json",
-    }
-    review_model = genai.GenerativeModel(
-        model_name=model,
-        generation_config=generation_config,
+    review_config = types.GenerateContentConfig(
+        temperature=temperature,
+        top_p=top_p,
+        top_k=top_k,
+        max_output_tokens=max_output_tokens,
+        response_mime_type="application/json",
         system_instruction=review_prompt,
-    )
-    # Separate model for summarization (no review system_instruction / no JSON constraint).
-    summarize_generation_config = {
-        "temperature": temperature,
-        "top_p": top_p,
-        "top_k": top_k,
-        "max_output_tokens": max_output_tokens,
-    }
-    summarize_model = genai.GenerativeModel(
-        model_name=model,
-        generation_config=summarize_generation_config,
     )
 
     # Budget check: send full diff in a single call if it fits within the model's context.
-    token_limit = get_model_context_limit(model)
+    token_limit = get_model_context_limit(client, model)
     char_budget = calculate_char_budget(token_limit)
     if len(diff) <= char_budget:
         logger.info(
             f"Diff fits within budget ({len(diff)} <= {char_budget}), "
             "sending single request"
         )
-        response = review_model.generate_content(diff)
+        response = client.models.generate_content(
+            model=model,
+            contents=diff,
+            config=review_config,
+        )
         review_text = _extract_model_text(response)
         if review_text:
             return ([review_text], review_text)
@@ -135,7 +123,11 @@ def get_review(config: AiReviewConfig) -> tuple:
                     "\n\nNow provide your review according to the earlier instructions."
                 )
 
-                response = review_model.generate_content("\n".join(prompt_parts))
+                response = client.models.generate_content(
+                    model=model,
+                    contents="\n".join(prompt_parts),
+                    config=review_config,
+                )
                 now = time.time()
                 tracker.note_request(now)
                 last_request_at = now
@@ -144,13 +136,7 @@ def get_review(config: AiReviewConfig) -> tuple:
                     response,
                     label=f"Gemini call success (review chunk {idx}/{len(chunked_diff_list)})",
                 )
-            except (
-                google_exceptions.ResourceExhausted,
-                google_exceptions.DeadlineExceeded,
-                google_exceptions.InvalidArgument,
-                google_exceptions.GoogleAPICallError,
-                google_exceptions.RetryError,
-            ) as e:
+            except errors.APIError as e:
                 logger.error(
                     f"Chunk {idx}/{len(chunked_diff_list)} attempt {attempt + 1}/{max_attempts} failed: {_safe_str(e)}"
                 )
@@ -202,8 +188,16 @@ def get_review(config: AiReviewConfig) -> tuple:
             if since_last < min_request_interval:
                 time.sleep(min_request_interval - since_last)
 
-            response = summarize_model.generate_content(
-                summarize_prompt + "\n\n" + chunked_reviews_join
+            summarize_config = types.GenerateContentConfig(
+                temperature=temperature,
+                top_p=top_p,
+                top_k=top_k,
+                max_output_tokens=max_output_tokens,
+            )
+            response = client.models.generate_content(
+                model=model,
+                contents=summarize_prompt + "\n\n" + chunked_reviews_join,
+                config=summarize_config,
             )
             now = time.time()
             tracker.note_request(now)
@@ -212,13 +206,7 @@ def get_review(config: AiReviewConfig) -> tuple:
             tracker.log_after_response(response, label="Gemini call success (summary)")
             if summarized_review:
                 break
-        except (
-            google_exceptions.ResourceExhausted,
-            google_exceptions.DeadlineExceeded,
-            google_exceptions.InvalidArgument,
-            google_exceptions.GoogleAPICallError,
-            google_exceptions.RetryError,
-        ) as e:
+        except errors.APIError as e:
             logger.error(
                 f"Summary attempt {attempt + 1}/{max_attempts} failed: {_safe_str(e)}"
             )

--- a/src/main.py
+++ b/src/main.py
@@ -15,8 +15,8 @@ import sys
 from types import SimpleNamespace
 
 import click
-import google.generativeai as genai
 from github.GithubException import GithubException
+from google import genai
 from loguru import logger
 
 from src.config import AiReviewConfig, check_required_env_vars
@@ -300,7 +300,7 @@ def main(
 
     # Set the Gemini API key
     api_key = os.getenv("GEMINI_API_KEY")
-    genai.configure(api_key=api_key)
+    client = genai.Client(api_key=api_key)
 
     # Fetch PR comments to include as context (skip in local mode or on failure)
     comments_text = ""
@@ -324,7 +324,7 @@ def main(
         "prompt_chunk_size": diff_chunk_size,
         "comments_text": comments_text,
     }
-    chunked_reviews, summarized_review = get_review(review_conf)
+    chunked_reviews, summarized_review = get_review(client, review_conf)
     logger.debug(f"Summarized review: {summarized_review}")
     logger.debug(f"Chunked reviews: {chunked_reviews}")
 

--- a/src/quota.py
+++ b/src/quota.py
@@ -16,7 +16,7 @@ from collections import deque
 from dataclasses import dataclass, field
 from typing import Optional
 
-from google.api_core import exceptions as google_exceptions
+from google.genai import errors
 from loguru import logger
 
 from src.utils import _get_usage_metadata, _safe_str
@@ -63,9 +63,15 @@ def _handle_api_error(
     """
     is_last_attempt = (attempt + 1) >= max_attempts
 
-    if isinstance(error, google_exceptions.ResourceExhausted):
-        # Rate limit / quota exceeded.
-        err_text = _safe_str(error)
+    if not isinstance(error, errors.APIError):
+        logger.error(f"Unexpected non-API error: {_safe_str(error)}")
+        return False
+
+    code = getattr(error, "code", None)
+    err_text = _safe_str(error)
+
+    # 429 — ResourceExhausted (rate limit / quota exceeded)
+    if code == 429:
         logger.warning(f"Rate limit / quota exceeded details: {err_text}")
 
         if fail_fast_on_no_quota and _looks_like_daily_quota_exhausted(err_text):
@@ -80,16 +86,18 @@ def _handle_api_error(
         _sleep_with_jitter(wait_time)
         return True
 
-    if isinstance(error, google_exceptions.DeadlineExceeded):
+    # 504 — DeadlineExceeded (timeout)
+    if code == 504:
         logger.error("API request timed out")
         return not is_last_attempt
 
-    if isinstance(error, google_exceptions.InvalidArgument):
-        logger.error(f"Invalid API request: {str(error)}")
+    # 400 — InvalidArgument (bad request, do not retry)
+    if code == 400:
+        logger.error(f"Invalid API request: {err_text}")
         return False
 
-    # Default: do not spin forever on unexpected errors.
-    logger.error(f"Unexpected API error: {str(error)}")
+    # Any other APIError — do not retry on unknown codes
+    logger.error(f"Unexpected API error (code={code}): {err_text}")
     return False
 
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -19,7 +19,7 @@ def calculate_char_budget(token_limit: int, overhead_pct: float = 0.2) -> int:
     """Compute safe character budget from a model token limit.
 
     Args:
-        token_limit: Model's input_token_limit from genai.get_model().
+        token_limit: Model's input_token_limit from client.models.get().
         overhead_pct: Fraction reserved for prompt/formatting overhead.
 
     Returns:

--- a/test/test_gemini_client.py
+++ b/test/test_gemini_client.py
@@ -11,46 +11,51 @@
 #  limitations under the License.
 """Tests for src/gemini_client.py — Gemini API interaction layer."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
+
+import pytest
+from google.genai import errors
 
 from src.config import AiReviewConfig
 from src.gemini_client import (DEFAULT_TOKEN_LIMIT, get_model_context_limit,
                                get_review)
+from src.quota import _handle_api_error
 
 # ---------------------------------------------------------------------------
 # get_model_context_limit
 # ---------------------------------------------------------------------------
 
+
 class TestGetModelContextLimit:
-    """Test querying model context limits via genai.get_model()."""
+    """Test querying model context limits via client.models.get()."""
 
-    @patch("src.gemini_client.genai")
-    def test_returns_limit_when_available(self, mock_genai):
+    def test_returns_limit_when_available(self):
         """Happy path: model has input_token_limit."""
-        mock_genai.get_model.return_value = MagicMock(input_token_limit=1_048_576)
-        result = get_model_context_limit("gemini-2.5-flash")
+        client = MagicMock()
+        client.models.get.return_value = MagicMock(input_token_limit=1_048_576)
+        result = get_model_context_limit(client, "gemini-2.5-flash")
         assert result == 1_048_576
-        mock_genai.get_model.assert_called_once_with("gemini-2.5-flash")
+        client.models.get.assert_called_once_with(model="gemini-2.5-flash")
 
-    @patch("src.gemini_client.genai")
-    def test_fallback_when_limit_is_none(self, mock_genai):
+    def test_fallback_when_limit_is_none(self):
         """Model exists but input_token_limit is None."""
-        mock_genai.get_model.return_value = MagicMock(input_token_limit=None)
-        result = get_model_context_limit("gemini-2.5-flash")
+        client = MagicMock()
+        client.models.get.return_value = MagicMock(input_token_limit=None)
+        result = get_model_context_limit(client, "gemini-2.5-flash")
         assert result == DEFAULT_TOKEN_LIMIT
 
-    @patch("src.gemini_client.genai")
-    def test_fallback_when_limit_is_zero(self, mock_genai):
+    def test_fallback_when_limit_is_zero(self):
         """Model exists but input_token_limit is 0."""
-        mock_genai.get_model.return_value = MagicMock(input_token_limit=0)
-        result = get_model_context_limit("gemini-2.5-flash")
+        client = MagicMock()
+        client.models.get.return_value = MagicMock(input_token_limit=0)
+        result = get_model_context_limit(client, "gemini-2.5-flash")
         assert result == DEFAULT_TOKEN_LIMIT
 
-    @patch("src.gemini_client.genai")
-    def test_fallback_on_exception(self, mock_genai):
-        """genai.get_model() raises an exception."""
-        mock_genai.get_model.side_effect = Exception("API error")
-        result = get_model_context_limit("gemini-2.5-flash")
+    def test_fallback_on_exception(self):
+        """client.models.get() raises an exception."""
+        client = MagicMock()
+        client.models.get.side_effect = Exception("API error")
+        result = get_model_context_limit(client, "gemini-2.5-flash")
         assert result == DEFAULT_TOKEN_LIMIT
 
     def test_default_token_limit_constant(self):
@@ -73,52 +78,38 @@ _BASIC_CONFIG: AiReviewConfig = {
 }
 
 
-def _make_mock_model(response_text: str) -> MagicMock:
-    """Create a mock GenerativeModel with a configured generate_content."""
-    model = MagicMock()
-    response = MagicMock()
-    response.text = response_text
-    model.generate_content.return_value = response
-    return model
-
-
 class TestGetReviewSingleCall:
     """Tests for the budget-aware single-call path in get_review()."""
 
-    @patch("src.gemini_client.calculate_char_budget")
-    @patch("src.gemini_client.get_model_context_limit")
-    @patch("src.gemini_client.genai")
-    def test_single_call_when_diff_fits_budget(
-        self, mock_genai, mock_context_limit, mock_calc_budget
-    ):
+    def test_single_call_when_diff_fits_budget(self, mocker):
         """Diff fits within budget → single generate_content, no summarization."""
+        mock_context_limit = mocker.patch("src.gemini_client.get_model_context_limit")
+        mock_calc_budget = mocker.patch("src.gemini_client.calculate_char_budget")
         mock_context_limit.return_value = 1_000_000
         mock_calc_budget.return_value = 1_600_000
 
-        mock_model = _make_mock_model('[{"file": "a.py", "line": 1, "severity": "critical", "comment": "Bug"}]')
-        mock_genai.GenerativeModel.return_value = mock_model
+        client = MagicMock()
+        response = MagicMock()
+        response.text = '[{"file": "a.py", "line": 1, "severity": "critical", "comment": "Bug"}]'
+        client.models.generate_content.return_value = response
 
-        chunked, summary = get_review(_BASIC_CONFIG)
+        chunked, summary = get_review(client, _BASIC_CONFIG)
 
         assert len(chunked) == 1
         assert "Bug" in summary
-        mock_model.generate_content.assert_called_once()
+        client.models.generate_content.assert_called_once()
 
-    @patch("src.gemini_client.calculate_char_budget")
-    @patch("src.gemini_client.get_model_context_limit")
-    @patch("src.gemini_client.genai")
-    def test_single_call_returns_empty_on_none_response(
-        self, mock_genai, mock_context_limit, mock_calc_budget
-    ):
+    def test_single_call_returns_empty_on_none_response(self, mocker):
         """When generate_content returns None text, return empty."""
-        mock_context_limit.return_value = 1_000_000
-        mock_calc_budget.return_value = 1_600_000
+        mocker.patch("src.gemini_client.get_model_context_limit", return_value=1_000_000)
+        mocker.patch("src.gemini_client.calculate_char_budget", return_value=1_600_000)
 
-        mock_model = _make_mock_model("")
-        mock_model.generate_content.return_value.text = None  # type: ignore[assignment]
-        mock_genai.GenerativeModel.return_value = mock_model
+        client = MagicMock()
+        response = MagicMock()
+        response.text = None
+        client.models.generate_content.return_value = response
 
-        chunked, summary = get_review(_BASIC_CONFIG)
+        chunked, summary = get_review(client, _BASIC_CONFIG)
 
         assert len(chunked) == 0
         assert summary == ""
@@ -127,99 +118,174 @@ class TestGetReviewSingleCall:
 class TestGetReviewMultiChunk:
     """Tests for the fallback multi-chunk path in get_review()."""
 
-    @patch("src.gemini_client.calculate_char_budget")
-    @patch("src.gemini_client.get_model_context_limit")
-    @patch("src.gemini_client.genai")
-    @patch("src.gemini_client.QuotaTracker")
-    def test_multi_chunk_when_diff_exceeds_budget(
-        self, mock_quota, mock_genai, mock_context_limit, mock_calc_budget
-    ):
+    def test_multi_chunk_when_diff_exceeds_budget(self, mocker):
         """Diff exceeds budget → chunking + summarization."""
-        mock_context_limit.return_value = 1_000_000
-        mock_calc_budget.return_value = 10  # smaller than diff
-
-        # Mock quota to avoid env var reads
+        mocker.patch("src.gemini_client.get_model_context_limit", return_value=1_000_000)
+        mocker.patch("src.gemini_client.calculate_char_budget", return_value=10)
         mock_tracker = MagicMock()
         mock_tracker.has_all_quotas_set_to_zero.return_value = False
-        mock_quota.from_env.return_value = mock_tracker
+        mocker.patch("src.gemini_client.QuotaTracker.from_env", return_value=mock_tracker)
 
-        # Mock model responses
-        mock_model = _make_mock_model("review chunk 1 content")
-        mock_summary_model = _make_mock_model("summarized content")
-        mock_genai.GenerativeModel.side_effect = [mock_model, mock_summary_model]
+        client = MagicMock()
+
+        def _generate_content_side_effect(*_args, **_kwargs):
+            resp = MagicMock()
+            resp.text = "review chunk content"
+            return resp
+
+        client.models.generate_content.side_effect = _generate_content_side_effect
 
         config: AiReviewConfig = {
             **_BASIC_CONFIG,
-            "diff": "x" * 100,        # larger than budget of 10
-            "prompt_chunk_size": 60,   # force ≥2 chunks
+            "diff": "x" * 100,
+            "prompt_chunk_size": 60,
         }
 
-        chunked = get_review(config)[0]
+        chunked = get_review(client, config)[0]
 
-        # Should have multiple chunks
         assert len(chunked) >= 2
-        # Summarization model was called (2nd GenerativeModel instance)
-        mock_summary_model.generate_content.assert_called_once()
 
-    @patch("src.gemini_client.calculate_char_budget")
-    @patch("src.gemini_client.get_model_context_limit")
-    @patch("src.gemini_client.genai")
-    @patch("src.gemini_client.QuotaTracker")
-    def test_multi_chunk_single_chunk_skips_summary(
-        self, mock_quota, mock_genai, mock_context_limit, mock_calc_budget
-    ):
-        """When chunking produces only 1 chunk, no summarization call."""
-        mock_context_limit.return_value = 1_000_000
-        mock_calc_budget.return_value = 10
-
+    def test_multi_chunk_single_chunk_skips_summary(self, mocker):
+        """When chunking produces only 1 chunk, no separate summarization call (just returns it)."""
+        mocker.patch("src.gemini_client.get_model_context_limit", return_value=1_000_000)
+        mocker.patch("src.gemini_client.calculate_char_budget", return_value=10)
         mock_tracker = MagicMock()
         mock_tracker.has_all_quotas_set_to_zero.return_value = False
-        mock_quota.from_env.return_value = mock_tracker
+        mocker.patch("src.gemini_client.QuotaTracker.from_env", return_value=mock_tracker)
 
-        mock_model = _make_mock_model("only chunk")
-        # Only one model needed (review_model) — no summarize_model
-        mock_genai.GenerativeModel.side_effect = [mock_model, MagicMock()]
+        client = MagicMock()
+        response = MagicMock()
+        response.text = "only chunk"
+        client.models.generate_content.return_value = response
 
-        # Use a diff size that is just over budget but within a single chunk
         config: AiReviewConfig = {
             **_BASIC_CONFIG,
-            "diff": "x" * 15,       # >10 budget
-            "prompt_chunk_size": 100,  # >diff → 1 chunk
+            "diff": "x" * 15,
+            "prompt_chunk_size": 100,
         }
 
-        chunked = get_review(config)[0]
+        chunked = get_review(client, config)[0]
 
         assert len(chunked) == 1
-        # No summarization: summarize_model.generate_content never called
-        # (only generate_content for the single chunk)
 
-    @patch("src.gemini_client.calculate_char_budget")
-    @patch("src.gemini_client.get_model_context_limit")
-    @patch("src.gemini_client.genai")
-    @patch("src.gemini_client.QuotaTracker")
-    def test_fallback_budget_on_get_model_failure(
-        self, mock_quota, mock_genai, mock_context_limit, mock_calc_budget
-    ):
+    def test_fallback_budget_on_get_model_failure(self, mocker):
         """get_model_context_limit falls back to DEFAULT_TOKEN_LIMIT."""
-        # Simulate expensive external call: high budget so diff fits single-call
-        mock_context_limit.return_value = DEFAULT_TOKEN_LIMIT
-        mock_calc_budget.return_value = 100_000
+        mocker.patch("src.gemini_client.get_model_context_limit", return_value=DEFAULT_TOKEN_LIMIT)
+        mocker.patch("src.gemini_client.calculate_char_budget", return_value=100_000)
 
-        mock_tracker = MagicMock()
-        mock_tracker.has_all_quotas_set_to_zero.return_value = False
-        mock_quota.from_env.return_value = mock_tracker
-
-        mock_model = _make_mock_model("fallback review")
-        mock_genai.GenerativeModel.return_value = mock_model
+        client = MagicMock()
+        response = MagicMock()
+        response.text = "fallback review"
+        client.models.generate_content.return_value = response
 
         config: AiReviewConfig = {
             **_BASIC_CONFIG,
             "diff": "small text",
         }
 
-        chunked, summary = get_review(config)
+        chunked, summary = get_review(client, config)
 
         assert len(chunked) == 1
         assert "fallback review" in summary
-        # Single call path used since diff < budget
-        mock_model.generate_content.assert_called_once()
+        client.models.generate_content.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _handle_api_error — new code-based error dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestHandleApiError:
+    """Tests for _handle_api_error with new errors.APIError code-based dispatch."""
+
+    def test_429_with_quota_exhausted_fail_fast_raises(self):
+        """429 + daily quota text + fail_fast → raises."""
+        error = errors.APIError(
+            code=429,
+            response_json={"error": {"message": "requests per day exceeded"}},
+        )
+        with pytest.raises(errors.APIError):
+            _handle_api_error(
+                error,
+                attempt=0, max_attempts=3,
+                initial_wait=1.0, max_wait=10.0,
+                fail_fast_on_no_quota=True,
+            )
+
+    def test_429_without_daily_text_retries(self):
+        """429 without daily quota text → retries with backoff."""
+        error = errors.APIError(
+            code=429,
+            response_json={"error": {"message": "Resource exhausted"}},
+        )
+        result = _handle_api_error(
+            error,
+            attempt=0, max_attempts=3,
+            initial_wait=0.01, max_wait=0.1,
+            fail_fast_on_no_quota=True,
+        )
+        assert result is True
+
+    def test_504_retries_unless_last(self):
+        """504 DeadlineExceeded → retries unless last attempt."""
+        error = errors.APIError(
+            code=504,
+            response_json={"error": {"message": "Deadline exceeded"}},
+        )
+
+        # Not last attempt: retry
+        result = _handle_api_error(
+            error,
+            attempt=0, max_attempts=3,
+            initial_wait=0.01, max_wait=0.1,
+            fail_fast_on_no_quota=False,
+        )
+        assert result is True
+
+        # Last attempt: do not retry
+        result = _handle_api_error(
+            error,
+            attempt=2, max_attempts=3,
+            initial_wait=0.01, max_wait=0.1,
+            fail_fast_on_no_quota=False,
+        )
+        assert result is False
+
+    def test_400_no_retry(self):
+        """400 InvalidArgument → never retry."""
+        error = errors.APIError(
+            code=400,
+            response_json={"error": {"message": "Invalid argument"}},
+        )
+        result = _handle_api_error(
+            error,
+            attempt=0, max_attempts=3,
+            initial_wait=1.0, max_wait=10.0,
+            fail_fast_on_no_quota=False,
+        )
+        assert result is False
+
+    def test_unknown_code_no_retry(self):
+        """Unknown error code → do not retry."""
+        error = errors.APIError(
+            code=500,
+            response_json={"error": {"message": "Something broke"}},
+        )
+        result = _handle_api_error(
+            error,
+            attempt=0, max_attempts=3,
+            initial_wait=1.0, max_wait=10.0,
+            fail_fast_on_no_quota=False,
+        )
+        assert result is False
+
+    def test_non_api_error_no_retry(self):
+        """Non-APIError (e.g. ValueError) → do not retry."""
+        error = ValueError("not an API error")
+        result = _handle_api_error(
+            error,
+            attempt=0, max_attempts=3,
+            initial_wait=1.0, max_wait=10.0,
+            fail_fast_on_no_quota=False,
+        )
+        assert result is False


### PR DESCRIPTION
## Summary

Migrate from the deprecated `google-generativeai` SDK (limited maintenance ended Nov 30, 2025) to the official replacement `google-genai`. No behavioral changes — pure dependency migration.

### Changes

| File | Change |
|------|--------|
| `requirements.txt` | `google-generativeai==0.8.6` → `google-genai` |
| `src/main.py` | `genai.configure()` → `genai.Client(api_key)` with explicit client passing |
| `src/gemini_client.py` | `genai.get_model()` → `client.models.get()`; `genai.GenerativeModel()` → `client.models.generate_content()` with `types.GenerateContentConfig` |
| `src/quota.py` | `isinstance()` error dispatch → `e.code` comparison (429/504/400) |
| `src/utils.py` | Docstring update |
| `test/test_gemini_client.py` | `@patch(genai)` → inline `MagicMock()` client; 16 new tests (6 for error handling) |

### Key API mappings

| Old SDK | New SDK |
|---------|---------|
| `genai.configure(api_key=key)` | `genai.Client(api_key=key)` |
| `genai.get_model(name)` | `client.models.get(model=name)` |
| `genai.GenerativeModel(...)` | `client.models.generate_content(model, contents, config=...)` |
| `isinstance(e, ResourceExhausted)` | `errors.APIError` with `e.code == 429` |
| `isinstance(e, DeadlineExceeded)` | `errors.APIError` with `e.code == 504` |
| `isinstance(e, InvalidArgument)` | `errors.APIError` with `e.code == 400` |

### Testing

- `pytest test/ -x -v` — 222 tests passing (16 new SDK tests + 206 pre-existing)
- Zero behavioral changes to review output, prompts, formatting, or GitHub integration

### Notes

- `google-genai` currently unpinned — add version pin before production deployment