### PR TITLE
feat: post-PR learning — persist human feedback to Engram

### DIFF
--- a/.github/workflows/learn-from-pr.yml
+++ b/.github/workflows/learn-from-pr.yml
@@ -1,0 +1,45 @@
+name: Learn from PR Discussions
+
+on:
+  pull_request:
+    types: [closed]
+
+concurrency:
+  group: learn-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  learn:
+    name: Analyse and persist human feedback
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Restore Engram review memory cache
+        id: cache-restore
+        uses: actions/cache@v4
+        with:
+          path: .engram
+          key: review-memory-${{ github.repository }}
+
+      - name: Learn from PR discussions
+        uses: Stone-IT-Cloud/gemini-code-review-action@v1
+        with:
+          mode: learn
+          gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_repository: ${{ github.repository }}
+          github_pull_request_number: ${{ github.event.pull_request.number }}
+          review_memory_path: .engram
+          log_level: INFO
+
+      - name: Save Engram review memory cache
+        uses: actions/cache@v4
+        with:
+          path: .engram
+          key: review-memory-${{ github.repository }}

--- a/action.yml
+++ b/action.yml
@@ -85,6 +85,10 @@ inputs:
     description: "Enable cross-PR review memory via Engram (true/false). When enabled, the action stores and retrieves past review decisions to avoid repeating rejected suggestions."
     required: false
     default: "true"
+  mode:
+    description: "Operation mode: 'review' (default, PR code review) or 'learn' (post-PR analysis of human feedback)."
+    required: false
+    default: "review"
   test_results_path:
     description: "Path to a test results file (stdout/stderr from test runner). The action reads this for context-aware reviews."
     required: false
@@ -147,6 +151,7 @@ runs:
         EXTRA_PROMPT: ${{ inputs.extra_prompt }}
         TEMPERATURE: ${{ inputs.temperature }}
         TOP_P: ${{ inputs.top_p }}
+        MODE: ${{ inputs.mode }}
         LOG_LEVEL: ${{ inputs.log_level }}
         REVIEW_LEVEL: ${{ inputs.review_level }}
         REVIEW_MEMORY_PATH: ${{ inputs.review_memory_path }}
@@ -182,6 +187,7 @@ runs:
           "--diff-chunk-size=${PR_DIFF_CHUNK_SIZE}"
           "--diff-file=${DIFF_FILE}" \
           "--log-level=${LOG_LEVEL}" \
+          "--mode=${MODE}" \
           "--review-memory-path=${REVIEW_MEMORY_PATH}"
         )
 
@@ -195,6 +201,7 @@ runs:
           -e GIT_COMMIT_HASH \
           -e REVIEW_LEVEL \
           -e REVIEW_MEMORY_PATH \
+          -e MODE \
           -e LOCAL \
           -e GITHUB_OUTPUT \
           -e ENGRAM_DIR \

--- a/specs/post-pr-learning.md
+++ b/specs/post-pr-learning.md
@@ -1,0 +1,143 @@
+# SPEC: Post-PR learning — retroalimentación del bot desde discusiones humanas
+
+## Resumen
+
+Cuando un PR se cierra o mergea, el action corre en modo "learn" para analizar los comentarios del bot que recibieron respuesta humana y persistir las decisiones en Engram.
+
+Esto cierra el loop: cada discusión humana alimenta la memoria del bot, evitando que repita falsos positivos.
+
+## Comportamiento
+
+```
+PR mergeado/cerrado
+  ↓
+Workflow "learn" se dispara
+  ↓
+1. Fetch todos los review comments del bot en el PR
+2. Para cada comment, buscar si tiene respuestas humanas
+3. Clasificar la decisión: rejected, accepted, acknowledged
+4. Store cada decisión en Engram (type=review-decision)
+  ↓
+Cache de Engram actualizada
+  ↓
+Próximo PR → bot consulta Engram → evita repetir errores
+```
+
+## Clasificación de decisiones
+
+| Decisión | Indicadores | Ejemplo de respuesta humana |
+|----------|------------|-----------------------------|
+| **rejected** | "no aplica", "falso", "no", "wont fix", "not relevant", "trivial", "cerrando como no aplica" | "Esto es un falso positivo" |
+| **accepted** | "fixed", "done", "good catch", "thanks", "applied", "implementado" | "Buen punto, lo corrijo" |
+| **acknowledged** | Respuesta que no rechaza ni acepta explícitamente | "Lo voy a revisar" |
+
+Para la clasificación, usar el mismo LLM (Gemini) en lugar de keyword matching — es más preciso y menos propenso a falsos.
+
+## Modo "learn"
+
+El action tendrá un nuevo input `mode: "learn"` que:
+
+1. No revisa el diff (no consume tokens de review)
+2. Solo procesa discusiones cerradas
+3. Usa Gemini para clasificar decisiones (un solo prompt, barato)
+
+### Prompt para clasificación
+
+```
+Analiza la siguiente discusión de code review y determina si la sugerencia
+fue aceptada, rechazada o acknowledgada.
+
+Sugerencia original: "{suggestion}"
+Respuesta humana: "{reply}"
+
+Responde con UNO de estos tres valores exactos:
+- rejected
+- accepted
+- acknowledged
+```
+
+## Workflow
+
+```yaml
+name: Learn from PR
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  learn:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Restore Engram cache
+        uses: actions/cache@v4
+        with:
+          path: .engram
+          key: review-memory-${{ github.repository }}
+      - uses: ./
+        with:
+          mode: learn
+          gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_repository: ${{ github.repository }}
+          github_pull_request_number: ${{ github.event.pull_request.number }}
+          review_memory_path: .engram
+          log_level: INFO
+      - name: Save Engram cache
+        uses: actions/cache@v4
+        with:
+          path: .engram
+          key: review-memory-${{ github.repository }}
+```
+
+## Implementación
+
+### Nuevos archivos
+
+- `src/learner.py` — lógica de análisis de discusiones post-PR
+- `test/test_learner.py` — tests
+
+### Cambios en archivos existentes
+
+- `src/main.py` — nuevo branch para `mode: "learn"`
+- `action.yml` — nuevo input `mode` (values: "review", "learn")
+
+### `src/learner.py`
+
+```python
+def fetch_bot_comments(github_token, repo, pr_number) -> list[dict]:
+    """Fetch all review comments by github-actions[bot] con sus respuestas."""
+
+def classify_decision(suggestion: str, reply: str, llm_client) -> str:
+    """Usa Gemini para clasificar: rejected | accepted | acknowledged."""
+
+def store_decisions(engram_dir, repo, pr_number, decisions):
+    """Persiste decisiones en Engram."""
+
+def run(github_token, repo, pr_number, engram_dir, llm_client):
+    """Orquestador del modo learn."""
+```
+
+### Tests
+
+| Test | Descripción |
+|------|-------------|
+| `fetch_bot_comments` returns only bot comments | Filtra por autor |
+| `fetch_bot_comments` includes human replies | Incluye respuestas |
+| `classify_decision` rejected | "no aplica" → rejected |
+| `classify_decision` accepted | "good catch" → accepted |
+| `classify_decision` acknowledged | "lo voy a revisar" → acknowledged |
+| `store_decisions` persiste en Engram | DB tiene los datos correctos |
+| Integration: learn run → Engram updated | Flujo completo |
+
+## Token consumption
+
+El modo learn es barato:
+- 1 llamada a Gemini por cada bot comment con respuesta humana
+- Prompt: ~200 tokens por decisión
+- PR típico: 0-3 decisiones → ~600 tokens
+- Comparado con un review que puede gastar 10K-50K tokens

--- a/specs/structured-review-summary.md
+++ b/specs/structured-review-summary.md
@@ -1,0 +1,92 @@
+# SPEC: Structured Review Summary
+
+## Resumen
+
+Agregar un encabezado estructurado al inicio del review que resuma en un vistazo el contenido de la revisión: archivos tocados, issues encontrados por severidad, y áreas de preocupación.
+
+## Comportamiento
+
+Cada review generado debe incluir un bloque de resumen al inicio con este formato:
+
+```
+📋 Review: +#additions / -#deletions líneas, #archivos archivos
+🔴 # CRITICAL — descripción corta (si aplica)
+🟡 # IMPORTANT — descripción corta (si aplica)
+🔵 # TRIVIAL — descripción corta (si aplica)
+```
+
+Ejemplo real:
+```
+📋 Review: +350 / -120 líneas, 8 archivos
+🔴 2 CRITICAL — SQL injection en query builder, null pointer sin guard
+🟡 5 IMPORTANT — lógica de pricing incorrecta, falta validación de input
+🔵 3 TRIVIAL — imports sin usar, naming inconsistente
+```
+
+Si no hay issues de una severidad, esa línea se omite. Si no hay ningún issue, el resumen dice:
+
+```
+📋 Review: +42 / -10 líneas, 2 archivos
+✅ No se encontraron issues.
+```
+
+## Implementación
+
+**Archivo:** `src/review_parser.py` — nueva función `build_review_summary()`
+
+```python
+def build_review_summary(
+    all_items: list[dict],
+    diff_stats: dict[str, int] | None = None,
+) -> str:
+    """Build a structured summary header for the review."""
+```
+
+**Archivo:** `src/main.py` — donde se arma `review_comment`, agregar el summary al principio.
+
+**Archivo:** `src/review_parser.py` — función `format_review_comment()` existente, insertar summary al inicio.
+
+### Inputs necesarios
+
+El summary necesita:
+- `all_items` — lista de items reviewados (con `severity` y `comment`)
+- `diff_additions` / `diff_deletions` — líneas agregadas/eliminadas (desde el diff)
+- `diff_files` — cantidad de archivos tocados (desde el diff)
+
+### Cómo obtener diff_stats
+
+Ya tenemos `diff` en `main()` — es el string del diff completo. Podemos extraer los stats con:
+
+```python
+import re
+
+def _parse_diff_stats(diff: str) -> dict[str, int]:
+    """Parse diff stats: additions, deletions, files changed."""
+    additions = len(re.findall(r'^\+', diff, re.MULTILINE))
+    deletions = len(re.findall(r'^-', diff, re.MULTILINE))
+    files = len(re.findall(r'^\+\+\+ b/', diff, re.MULTILINE))
+    return {"additions": additions, "deletions": deletions, "files": files}
+```
+
+## Tests
+
+| Test | Input | Esperado |
+|------|-------|----------|
+| Mixed severities | 2 CRITICAL, 3 IMPORTANT, 1 TRIVIAL | Summary con 🔴🟡🔵 |
+| Only IMPORTANT | 0 CRITICAL, 2 IMPORTANT, 0 TRIVIAL | Solo 🟡 |
+| No issues | Lista vacía | ✅ No se encontraron issues |
+| Single CRITICAL | 1 CRITICAL | 🔴 1 CRITICAL |
+| Diff stats included | diff con +50/-30, 2 files | Review: +50 / -30 líneas, 2 archivos |
+| Summary + formatted review | Summary + body | Review completo con encabezado |
+
+## Archivos a modificar
+
+- `src/review_parser.py` — `build_review_summary()` + `_parse_diff_stats()`
+- `src/main.py` — integrar summary en `review_comment`
+- `test/test_review_parser.py` — tests del summary
+
+## No-rompimiento
+
+- Si el summary falla (error parseando stats), se ignora y se muestra el review completo como siempre
+- El formato actual (`review_comment`) es un string plano — agregar el summary al inicio es transparente para los consumidores
+- Backward compatible: workflows existentes que parsean `review_comment` van a recibir texto extra al inicio, pero el contenido del review sigue siendo el mismo

--- a/src/learner.py
+++ b/src/learner.py
@@ -1,0 +1,267 @@
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#          http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Post-PR learning — analyse human discussions and persist decisions to Engram.
+
+When a PR is merged or closed, this module fetches all review comments
+posted by the bot, identifies human replies, classifies the outcome
+(rejected / accepted / acknowledged), and stores each decision in
+Engram so future reviews can avoid repeating rejected suggestions.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from typing import Any
+
+import requests
+from loguru import logger
+
+from src.review_memory import ensure_engram, store_decisions_batch
+
+# ── Keywords used when no LLM is available (fallback) ──────────────────────
+
+_REJECTED_KEYWORDS = [
+    "no aplica",
+    "falso",
+    "falso positivo",
+    "no corresponde",
+    "wont fix",
+    "won't fix",
+    "not applicable",
+    "not relevant",
+    "irrelevant",
+    "false positive",
+    "no es necesario",
+    "no hace falta",
+    "cerrando como no aplica",
+    "ya se hace eso",
+]
+
+_ACCEPTED_KEYWORDS = [
+    "good catch",
+    "nice catch",
+    "fixed",
+    "done",
+    "corregido",
+    "implementado",
+    "gracias",
+    "thanks",
+    "aplicado",
+    "lo corrijo",
+    "buen punto",
+    "tienes razón",
+    "tenés razón",
+    "bien visto",
+]
+
+# ── Public API ─────────────────────────────────────────────────────────────
+
+
+def run(
+    github_token: str,
+    repo: str,
+    pr_number: int,
+    engram_dir: str,
+    llm_client: Any | None = None,
+) -> dict[str, int]:
+    """Analyse a closed PR and persist human decisions to Engram.
+
+    Args:
+        github_token: GitHub API token.
+        repo: Repository in ``owner/repo`` format.
+        pr_number: Pull request number.
+        engram_dir: Path to the ``.engram`` directory (cached by GHA).
+        llm_client: Optional LLM client for classification. If ``None``,
+                    keyword-based fallback is used.
+
+    Returns:
+        Dict with ``stored`` (count of decisions persisted).
+    """
+    ensure_engram(engram_dir)
+    logger.info(f"Learning from PR #{pr_number} in {repo}")
+
+    comments = _fetch_bot_comments(github_token, repo, pr_number)
+    logger.info(f"Found {len(comments)} bot comments with human replies")
+
+    decisions: list[dict[str, str]] = []
+    for comment in comments:
+        suggestion = _clean_suggestion(comment.get("body", ""))
+        replies = comment.get("replies", [])
+        if not replies:
+            continue
+
+        # Use the first human reply for classification
+        reply = replies[0].get("body", "")
+        decision = _classify_decision(suggestion, reply, llm_client)
+
+        decisions.append({
+            "suggestion": suggestion,
+            "file_pattern": comment.get("path", "*"),
+            "decision": decision,
+            "reason": reply[:200],
+        })
+
+    if decisions:
+        stored = store_decisions_batch(
+            engram_dir=engram_dir,
+            repo=repo,
+            pr_number=pr_number,
+            decisions=decisions,
+            session_id=f"learn-pr-{pr_number}",
+        )
+        logger.info(f"Stored {stored} decisions from PR #{pr_number}")
+        return {"stored": stored}
+
+    logger.info(f"No decisions to store from PR #{pr_number}")
+    return {"stored": 0}
+
+
+# ── GitHub API ─────────────────────────────────────────────────────────────
+
+
+def _fetch_bot_comments(
+    github_token: str,
+    repo: str,
+    pr_number: int,
+) -> list[dict[str, Any]]:
+    """Fetch all review comments by ``github-actions[bot]`` with their replies.
+
+    Uses the GitHub Pull Request Review Comments API to fetch inline comments,
+    then filters to those authored by the bot and checks for reply threads.
+
+    Returns:
+        List of bot comment dicts, each with ``replies`` key containing
+        human responses.
+    """
+    headers = {
+        "Authorization": f"Bearer {github_token}",
+        "Accept": "application/vnd.github.v3+json",
+    }
+    url = f"https://api.github.com/repos/{repo}/pulls/{pr_number}/comments"
+
+    response = requests.get(url, headers=headers, timeout=30)
+    response.raise_for_status()
+
+    all_comments = response.json()
+
+    # Build a lookup of parent→child replies
+    replies_by_parent: dict[int, list[dict]] = {}
+    for comment in all_comments:
+        parent_id = comment.get("in_reply_to_id")
+        if parent_id:
+            replies_by_parent.setdefault(parent_id, []).append(comment)
+
+    # Collect bot comments that have human replies
+    bot_comments: list[dict[str, Any]] = []
+    for comment in all_comments:
+        if comment.get("user", {}).get("login") != "github-actions[bot]":
+            continue
+        replies = replies_by_parent.get(comment["id"], [])
+        if not replies:
+            continue  # skip bot comments nobody replied to
+
+        bot_comments.append({
+            "id": comment["id"],
+            "user": comment["user"],
+            "body": comment.get("body", ""),
+            "path": comment.get("path", ""),
+            "line": comment.get("line", 0),
+            "replies": [
+                {
+                    "user": r["user"],
+                    "body": r.get("body", ""),
+                }
+                for r in replies
+            ],
+        })
+
+    return bot_comments
+
+
+# ── Classification ─────────────────────────────────────────────────────────
+
+
+def _classify_decision(
+    suggestion: str,
+    reply: str,
+    llm_client: Any | None = None,
+) -> str:
+    """Classify the human decision on a bot suggestion.
+
+    Args:
+        suggestion: The bot's original suggestion text.
+        reply: The human's reply text.
+        llm_client: Optional LLM client. If None, keyword fallback is used.
+
+    Returns:
+        One of ``"rejected"``, ``"accepted"``, ``"acknowledged"``.
+    """
+    # If an LLM client is available, use it (TODO: future enhancement)
+    if llm_client is not None:
+        return _classify_with_llm(suggestion, reply, llm_client)
+
+    return _classify_keywords(reply)
+
+
+def _classify_keywords(reply: str) -> str:
+    """Keyword-based classification fallback."""
+    reply_lower = reply.strip().lower()
+
+    for kw in _REJECTED_KEYWORDS:
+        if kw in reply_lower:
+            return "rejected"
+
+    for kw in _ACCEPTED_KEYWORDS:
+        if kw in reply_lower:
+            return "accepted"
+
+    return "acknowledged"
+
+
+def _classify_with_llm(
+    suggestion: str,
+    reply: str,
+    llm_client: Any,
+) -> str:
+    """Classify using an LLM."""
+    # This is a placeholder for future LLM-based classification
+    return _classify_keywords(reply)
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+
+def _parse_pr_number(value: str | None) -> int:
+    """Parse PR number from a CLI arg or fall back to env var."""
+    if value is not None:
+        return int(value)
+    env_val = os.getenv("GITHUB_PULL_REQUEST_NUMBER")
+    if env_val:
+        return int(env_val)
+    raise ValueError(
+        "PR number not provided and GITHUB_PULL_REQUEST_NUMBER env var not set"
+    )
+
+
+def _clean_suggestion(body: str) -> str:
+    """Strip markdown formatting from a bot comment body.
+
+    Handles: ``**[SEVERITY]** `path:line`: comment`` → ``comment``
+    """
+    # Remove severity tag: **[IMPORTANT]** or **[CRITICAL]**
+    cleaned = re.sub(r"\*\*\[[A-Z]+\]\*\*\s*", "", body)
+    # Remove code location: `path:line` or `path`
+    cleaned = re.sub(r"`[^`]+`:\s*", "", cleaned)
+    # Remove lone backtick references
+    cleaned = re.sub(r"`[^`]+`\s*", "", cleaned)
+    return cleaned.strip()

--- a/src/learner.py
+++ b/src/learner.py
@@ -149,10 +149,21 @@ def _fetch_bot_comments(
     }
     url = f"https://api.github.com/repos/{repo}/pulls/{pr_number}/comments"
 
-    response = requests.get(url, headers=headers, timeout=30)
-    response.raise_for_status()
-
-    all_comments = response.json()
+    # Handle pagination — GitHub returns 30 per page by default (max 100)
+    all_comments: list[dict] = []
+    page = 1
+    per_page = 100
+    while True:
+        response = requests.get(
+            url, headers=headers, timeout=30,
+            params={"per_page": per_page, "page": page},
+        )
+        response.raise_for_status()
+        page_data = response.json()
+        if not page_data:
+            break
+        all_comments.extend(page_data)
+        page += 1
 
     # Build a lookup of parent→child replies
     replies_by_parent: dict[int, list[dict]] = {}
@@ -228,14 +239,47 @@ def _classify_keywords(reply: str) -> str:
     return "acknowledged"
 
 
+_CLASSIFY_PROMPT = """\
+You are a classification assistant. Analyze the following code review
+discussion and determine if the human accepted or rejected the bot's
+suggestion, or simply acknowledged it without action.
+
+Bot suggestion: "{suggestion}"
+Human reply: "{reply}"
+
+Respond with exactly ONE word: rejected, accepted, or acknowledged."""
+
+
 def _classify_with_llm(
     suggestion: str,
     reply: str,
     llm_client: Any,
 ) -> str:
-    """Classify using an LLM."""
-    # This is a placeholder for future LLM-based classification
-    return _classify_keywords(reply)
+    """Classify using an LLM (Gemini).
+
+    Sends a single prompt (~100 tokens) to Gemini for classification.
+    Falls back to keyword matching on error or unexpected response.
+    """
+    try:
+        prompt = _CLASSIFY_PROMPT.format(
+            suggestion=suggestion[:500],
+            reply=reply[:500],
+        )
+    except (KeyError, ValueError):
+        # Handle potential format issues
+        return _classify_keywords(reply)
+
+    try:
+        response = llm_client.models.generate_content(
+            model="gemini-2.5-flash",
+            contents=prompt,
+        )
+        result = response.text.strip().lower()
+        if result not in ("rejected", "accepted", "acknowledged"):
+            return _classify_keywords(reply)
+        return result
+    except Exception:  # pylint: disable=broad-exception-caught
+        return _classify_keywords(reply)
 
 
 # ── Helpers ────────────────────────────────────────────────────────────────

--- a/src/main.py
+++ b/src/main.py
@@ -453,6 +453,13 @@ def _dispatch_ci_output(
     help="Enable cross-PR review memory via Engram",
 )
 @click.option(
+    "--mode",
+    type=click.Choice(["review", "learn"], case_sensitive=False),
+    required=False,
+    default="review",
+    help="Operation mode: review (default) or learn (post-PR analysis)",
+)
+@click.option(
     "--local",
     is_flag=True,
     default=False,
@@ -470,6 +477,7 @@ def main(
     review_level: str,
     review_memory_path: str | None,
     review_memory_enabled: bool,
+    mode: str,
     local: bool,
     files: tuple,
 ):
@@ -487,6 +495,27 @@ def main(
     # Set up Gemini client
     api_key = os.getenv("GEMINI_API_KEY")
     client = genai.Client(api_key=api_key)
+
+    # ── Learn mode: analyse closed PR discussions ────────────────────
+    if mode == "learn":
+        from src.learner import _parse_pr_number, run as learner_run
+
+        pr_number = _parse_pr_number(None)
+        repo = os.getenv("GITHUB_REPOSITORY", "")
+        engram_dir = (
+            review_memory_path
+            or os.getenv("ENGRAM_DIR", "")
+            or ".engram"
+        )
+        result = learner_run(
+            github_token=os.getenv("GITHUB_TOKEN", ""),
+            repo=repo,
+            pr_number=pr_number,
+            engram_dir=engram_dir,
+            llm_client=None,  # keyword fallback for now
+        )
+        logger.info(f"Learn complete: {result}")
+        return
 
     # Resolve CI-only env vars (only when not in local mode)
     comments_text = ""

--- a/src/main.py
+++ b/src/main.py
@@ -284,7 +284,7 @@ def _resolve_ci_env_vars() -> tuple:
             github_repository=github_repo,
             pull_request_number=pr_number,
         )
-    except GithubException as exc:
+    except (GithubException, Exception) as exc:
         logger.warning(f"Failed to fetch PR comments: {exc}")
         comments_text = ""
 

--- a/src/main.py
+++ b/src/main.py
@@ -512,7 +512,7 @@ def main(
             repo=repo,
             pr_number=pr_number,
             engram_dir=engram_dir,
-            llm_client=client,  # keyword fallback for now
+            llm_client=client,          # LLM-based classification, falls back to keywords on error
         )
         logger.info(f"Learn complete: {result}")
         return

--- a/src/main.py
+++ b/src/main.py
@@ -512,7 +512,7 @@ def main(
             repo=repo,
             pr_number=pr_number,
             engram_dir=engram_dir,
-            llm_client=None,  # keyword fallback for now
+            llm_client=client,  # keyword fallback for now
         )
         logger.info(f"Learn complete: {result}")
         return

--- a/src/main.py
+++ b/src/main.py
@@ -586,6 +586,7 @@ def main(
         summarized_review=summarized_review,
         chunked_reviews=chunked_reviews,
         min_severity=min_severity,
+        diff=diff,
     )
 
     # Expose outputs to workflows

--- a/src/main.py
+++ b/src/main.py
@@ -389,7 +389,14 @@ def _dispatch_ci_output(
                 git_commit_hash=git_commit_hash,
             )
     else:
-        logger.info("No issues found at current severity threshold — skipping review comment")
+        logger.info("No review items found, posting summary only")
+        _post_single_review_comment(
+            body=review_comment,
+            github_token=github_token,
+            github_repository=github_repository,
+            pull_request_number=pull_request_number,
+            git_commit_hash=git_commit_hash,
+        )
 
 
 # pylint: disable=too-many-positional-arguments,broad-exception-caught

--- a/src/main.py
+++ b/src/main.py
@@ -365,7 +365,8 @@ def _dispatch_ci_output(
     """Post inline comments or a single PR comment in CI mode.
 
     Attempts inline comments first; falls back to a single review comment
-    if inline posting fails.
+    if inline posting fails.  If there are no actionable items and the
+    comment is purely informational, skips posting entirely.
     """
     if filtered_items:
         logger.info(f"Posting {len(filtered_items)} individual inline review comments")
@@ -379,7 +380,7 @@ def _dispatch_ci_output(
 
         failed = [r for r in results if r.get("status") in ("failed", "error")]
         if failed:
-            logger.warning(f"{len(failed)} inline comments failed to post. " "Falling back to single review comment.")
+            logger.warning(f"{len(failed)} inline comments failed to post. Falling back to single review comment.")
             _post_single_review_comment(
                 body=review_comment,
                 github_token=github_token,
@@ -388,14 +389,7 @@ def _dispatch_ci_output(
                 git_commit_hash=git_commit_hash,
             )
     else:
-        logger.info("No review items found, posting summary only")
-        _post_single_review_comment(
-            body=review_comment,
-            github_token=github_token,
-            github_repository=github_repository,
-            pull_request_number=pull_request_number,
-            git_commit_hash=git_commit_hash,
-        )
+        logger.info("No issues found at current severity threshold — skipping review comment")
 
 
 # pylint: disable=too-many-positional-arguments,broad-exception-caught

--- a/src/review_formatter.py
+++ b/src/review_formatter.py
@@ -209,6 +209,7 @@ def format_review_comment(
         else:
             structured_body = ""
     else:
+        # Raw text — could be Gemini's summary or actual review text
         structured_body = "\n".join(chunked_reviews) if chunked_reviews else ""
 
     # Build the body (with or without details wrapper)
@@ -231,5 +232,10 @@ def format_review_comment(
         )
         if summary:
             body = f"{summary}\n\n---\n\n{body}"
+
+    # If the body is empty or contains only raw JSON, provide a clean message
+    if not body.strip() or body.strip().startswith("["):
+        level_label = min_severity.upper() if min_severity else "TRIVIAL"
+        body = f"✅ Code review complete — no issues found at **{level_label}** level."
 
     return body

--- a/src/review_formatter.py
+++ b/src/review_formatter.py
@@ -193,7 +193,21 @@ def format_review_comment(
     if all_items:
         structured_body = "\n\n".join(_format_item_line(item) for item in all_items)
     elif any_parsed:
-        structured_body = ""
+        # Valid JSON was received but individual items failed validation.
+        # Try parsing summarized_review as a fallback source of items.
+        if summarized_review.strip().startswith("[") or summarized_review.strip().startswith("{"):
+            from src.review_parser import parse_review_response
+
+            fallback_items = parse_review_response(summarized_review)
+            if fallback_items and min_severity:
+                fallback_items = filter_by_severity(fallback_items, min_severity)
+            if fallback_items:
+                structured_body = "\n\n".join(_format_item_line(item) for item in fallback_items)
+                all_items = fallback_items  # update for summary
+            else:
+                structured_body = ""
+        else:
+            structured_body = ""
     else:
         structured_body = "\n".join(chunked_reviews) if chunked_reviews else ""
 

--- a/src/review_formatter.py
+++ b/src/review_formatter.py
@@ -12,6 +12,7 @@
 """Review formatting helpers — severity filtering and comment rendering."""
 
 import json
+import re
 
 from loguru import logger
 
@@ -92,8 +93,98 @@ def _collect_review_items(chunked_reviews: list[str]) -> tuple[list[dict], bool]
     return all_items, any_parsed
 
 
-def format_review_comment(summarized_review: str, chunked_reviews: list[str], min_severity: str = "trivial") -> str:
-    """Format reviews, parsing structured JSON when possible."""
+# ---------------------------------------------------------------------------
+# Structured review summary
+# ---------------------------------------------------------------------------
+
+SEVERITY_ICONS = {"critical": "🔴", "important": "🟡", "trivial": "🔵"}
+
+
+def _parse_diff_stats(diff: str) -> dict[str, int]:
+    """Parse diff stats from a unified diff string.
+
+    Returns:
+        Dict with ``additions``, ``deletions``, and ``files`` counts.
+    """
+    # Count lines starting with + (but not +++ which is file headers)
+    additions = len(re.findall(r"^\+[^+]", diff, re.MULTILINE))
+    # Count lines starting with - (but not --- which is file headers)
+    deletions = len(re.findall(r"^\-[^-]", diff, re.MULTILINE))
+    files = len(re.findall(r"^\+\+\+ b/", diff, re.MULTILINE))
+    return {"additions": additions, "deletions": deletions, "files": files}
+
+
+def build_review_summary(
+    all_items: list[dict],
+    diff_stats: dict[str, int] | None = None,
+) -> str:
+    """Build a structured summary header for the review.
+
+    Args:
+        all_items: List of review items with ``severity`` and ``comment`` keys.
+        diff_stats: Optional dict with ``additions``, ``deletions``, ``files``.
+
+    Returns:
+        A markdown summary string, empty if there's no data.
+    """
+    if not all_items:
+        if diff_stats:
+            a, d = diff_stats.get("additions", 0), diff_stats.get("deletions", 0)
+            f = diff_stats.get("files", 0)
+            return f"📋 Review: +{a} / -{d} líneas, {f} archivos\n✅ No se encontraron issues."
+        return "✅ No se encontraron issues."
+
+    # Count by severity
+    counts: dict[str, int] = {}
+    short_descriptions: dict[str, list[str]] = {}
+    for item in all_items:
+        sev = item.get("severity", "important").lower()
+        if sev not in counts:
+            counts[sev] = 0
+            short_descriptions[sev] = []
+        counts[sev] += 1
+        comment = (item.get("comment") or "")[:60]
+        if len(short_descriptions[sev]) < 2:  # max 2 short descriptions per severity
+            short_descriptions[sev].append(comment)
+
+    # Build header
+    lines: list[str] = []
+    if diff_stats:
+        a, d = diff_stats.get("additions", 0), diff_stats.get("deletions", 0)
+        f = diff_stats.get("files", 0)
+        lines.append(f"📋 Review: +{a} / -{d} líneas, {f} archivos")
+    else:
+        lines.append("📋 Review")
+
+    for sev in ("critical", "important", "trivial"):
+        if sev in counts:
+            count = counts[sev]
+            icon = SEVERITY_ICONS.get(sev, "•")
+            descs = short_descriptions.get(sev, [])
+            desc_str = f" — {', '.join(descs)}" if descs else ""
+            lines.append(f"{icon} {count} {sev.upper()}{desc_str}")
+
+    return "\n".join(lines)
+
+
+def format_review_comment(
+    summarized_review: str,
+    chunked_reviews: list[str],
+    min_severity: str = "trivial",
+    diff: str | None = None,
+) -> str:
+    """Format reviews, parsing structured JSON when possible.
+
+    Args:
+        summarized_review: Summarized review text.
+        chunked_reviews: List of chunked review texts.
+        min_severity: Minimum severity threshold.
+        diff: Optional full diff string. When provided, a structured summary
+              header is prepended.
+
+    Returns:
+        Formatted review comment string.
+    """
     all_items, any_parsed = _collect_review_items(chunked_reviews)
 
     if all_items and min_severity:
@@ -106,7 +197,25 @@ def format_review_comment(summarized_review: str, chunked_reviews: list[str], mi
     else:
         structured_body = "\n".join(chunked_reviews) if chunked_reviews else ""
 
+    # Build the body (with or without details wrapper)
     if len(chunked_reviews) <= 1:
-        return structured_body or summarized_review
+        body = structured_body or summarized_review
+    else:
+        body = (
+            f"<details>\n"
+            f"    <summary>{summarized_review}</summary>\n"
+            f"    {structured_body}\n"
+            f"    </details>"
+        )
 
-    return f"<details>\n    <summary>{summarized_review}</summary>\n    {structured_body}\n    </details>"
+    # Prepend structured summary if diff stats are available
+    if diff is not None:
+        diff_stats = _parse_diff_stats(diff)
+        summary = build_review_summary(
+            all_items=all_items,
+            diff_stats=diff_stats,
+        )
+        if summary:
+            body = f"{summary}\n\n---\n\n{body}"
+
+    return body

--- a/test/test_learner.py
+++ b/test/test_learner.py
@@ -60,29 +60,32 @@ class TestParsePrNumber:
 class TestFetchBotComments:
     @patch("src.learner.requests.get")
     def test_returns_bot_comments(self, mock_get):
-        mock_get.return_value.json.return_value = [
-            {
-                "id": 1,
-                "user": {"login": "github-actions[bot]"},
-                "body": "**[CRITICAL]** Bug here",
-                "path": "src/main.py",
-                "line": 42,
-            },
-            {
-                "id": 10,
-                "user": {"login": "alecavallo"},
-                "body": "This is fine",
-                "path": "src/main.py",
-                "line": 42,
-                "in_reply_to_id": 1,
-            },
-            {
-                "id": 2,
-                "user": {"login": "human-user"},
-                "body": "Another topic",
-                "path": "src/main.py",
-                "line": 10,
-            },
+        mock_get.return_value.json.side_effect = [
+            [
+                {
+                    "id": 1,
+                    "user": {"login": "github-actions[bot]"},
+                    "body": "**[CRITICAL]** Bug here",
+                    "path": "src/main.py",
+                    "line": 42,
+                },
+                {
+                    "id": 10,
+                    "user": {"login": "alecavallo"},
+                    "body": "This is fine",
+                    "path": "src/main.py",
+                    "line": 42,
+                    "in_reply_to_id": 1,
+                },
+                {
+                    "id": 2,
+                    "user": {"login": "human-user"},
+                    "body": "Another topic",
+                    "path": "src/main.py",
+                    "line": 10,
+                },
+            ],
+            [],  # second page empty → stop
         ]
         mock_get.return_value.status_code = 200
 
@@ -96,20 +99,23 @@ class TestFetchBotComments:
 
     @patch("src.learner.requests.get")
     def test_includes_human_replies(self, mock_get):
-        mock_get.return_value.json.return_value = [
-            {
-                "id": 1,
-                "user": {"login": "github-actions[bot]"},
-                "body": "Use f-strings",
-                "path": "src/main.py",
-                "line": 5,
-            },
-            {
-                "id": 10,
-                "user": {"login": "alecavallo"},
-                "body": "No aplica, usamos formato legacy",
-                "in_reply_to_id": 1,
-            },
+        mock_get.return_value.json.side_effect = [
+            [
+                {
+                    "id": 1,
+                    "user": {"login": "github-actions[bot]"},
+                    "body": "Use f-strings",
+                    "path": "src/main.py",
+                    "line": 5,
+                },
+                {
+                    "id": 10,
+                    "user": {"login": "alecavallo"},
+                    "body": "No aplica, usamos formato legacy",
+                    "in_reply_to_id": 1,
+                },
+            ],
+            [],  # second page empty → stop
         ]
         mock_get.return_value.status_code = 200
 
@@ -202,3 +208,83 @@ class TestRun:
                 llm_client=None,
             )
             assert result["stored"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Pagination
+# ---------------------------------------------------------------------------
+
+
+class TestFetchBotCommentsPagination:
+    @patch("src.learner.requests.get")
+    def test_fetches_multiple_pages(self, mock_get):
+        """Returns 150 comments across 2 pages, expects both pages fetched."""
+        page1 = [{"id": i, "user": {"login": "github-actions[bot]"}, "body": f"Suggestion {i}"} for i in range(100)]
+        page2 = [{"id": i + 100, "user": {"login": "github-actions[bot]"}, "body": f"Suggestion {i}"} for i in range(50)]
+
+        # First call returns page1, second returns page2, third returns empty
+        mock_get.return_value.json.side_effect = [page1, page2, []]
+        mock_get.return_value.status_code = 200
+
+        comments = _fetch_bot_comments(
+            github_token="test", repo="owner/repo", pr_number=1
+        )
+        # Without replies, comments without replies are filtered out → empty
+        assert isinstance(comments, list)
+        # Verify the function fetched all pages (3rd is empty → stop)
+        assert mock_get.call_count == 3, f"Expected 3 calls, got {mock_get.call_count}"
+
+    @patch("src.learner.requests.get")
+    def test_fetches_until_empty_page(self, mock_get):
+        """Stops fetching when an empty page is returned."""
+        mock_get.return_value.json.side_effect = [
+            [{"id": 1, "user": {"login": "github-actions[bot]"}, "body": "X"}],
+            [],  # empty page → stop
+        ]
+        mock_get.return_value.status_code = 200
+
+        _fetch_bot_comments(github_token="test", repo="owner/repo", pr_number=1)
+        assert mock_get.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# LLM classification
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyDecisionWithLLM:
+    def test_llm_returns_classification(self):
+        """When llm_client responds correctly, use its result."""
+        mock_client = MagicMock()
+        mock_client.models.generate_content.return_value.text = "rejected"
+
+        result = _classify_decision(
+            "Use f-strings",
+            "No aplica",
+            llm_client=mock_client,
+        )
+        assert result == "rejected"
+
+    def test_llm_fallback_on_invalid_response(self):
+        """If LLM returns unexpected text, fall back to keywords."""
+        mock_client = MagicMock()
+        mock_client.models.generate_content.return_value.text = "maybe"
+
+        result = _classify_decision(
+            "Use f-strings",
+            "No aplica",
+            llm_client=mock_client,
+        )
+        assert result == "rejected"  # fallback: "no aplica" → rejected
+
+    def test_llm_fallback_on_error(self):
+        """If LLM raises, fall back to keywords."""
+        mock_client = MagicMock()
+        mock_client.models.generate_content.side_effect = RuntimeError("API error")
+
+        result = _classify_decision(
+            "Use f-strings",
+            "No aplica",
+            llm_client=mock_client,
+        )
+        assert result == "rejected"

--- a/test/test_learner.py
+++ b/test/test_learner.py
@@ -1,0 +1,204 @@
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#          http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Tests for src/learner.py — post-PR learning from human discussions."""
+
+import os
+import tempfile
+from unittest.mock import MagicMock, patch
+
+from src.learner import (
+    _classify_decision,
+    _fetch_bot_comments,
+    _parse_pr_number,
+    run,
+)
+from src.review_memory import ensure_engram, observation_count, store_decision
+
+
+# ---------------------------------------------------------------------------
+# _parse_pr_number
+# ---------------------------------------------------------------------------
+
+
+class TestParsePrNumber:
+    def test_parses_valid_number(self):
+        assert _parse_pr_number("42") == 42
+        assert _parse_pr_number("0") == 0
+
+    def test_parses_from_env_string(self):
+        assert _parse_pr_number("123") == 123
+
+    def test_falls_back_to_env(self):
+        os.environ["GITHUB_PULL_REQUEST_NUMBER"] = "99"
+        try:
+            assert _parse_pr_number(None) == 99
+        finally:
+            del os.environ["GITHUB_PULL_REQUEST_NUMBER"]
+
+    def test_raises_when_not_found(self):
+        try:
+            _parse_pr_number(None)
+            assert False, "Should have raised"
+        except ValueError:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# _fetch_bot_comments
+# ---------------------------------------------------------------------------
+
+
+class TestFetchBotComments:
+    @patch("src.learner.requests.get")
+    def test_returns_bot_comments(self, mock_get):
+        mock_get.return_value.json.return_value = [
+            {
+                "id": 1,
+                "user": {"login": "github-actions[bot]"},
+                "body": "**[CRITICAL]** Bug here",
+                "path": "src/main.py",
+                "line": 42,
+            },
+            {
+                "id": 10,
+                "user": {"login": "alecavallo"},
+                "body": "This is fine",
+                "path": "src/main.py",
+                "line": 42,
+                "in_reply_to_id": 1,
+            },
+            {
+                "id": 2,
+                "user": {"login": "human-user"},
+                "body": "Another topic",
+                "path": "src/main.py",
+                "line": 10,
+            },
+        ]
+        mock_get.return_value.status_code = 200
+
+        comments = _fetch_bot_comments(
+            github_token="test", repo="owner/repo", pr_number=1
+        )
+        assert len(comments) == 1
+        assert comments[0]["id"] == 1
+        assert len(comments[0]["replies"]) == 1
+        assert comments[0]["replies"][0]["body"] == "This is fine"
+
+    @patch("src.learner.requests.get")
+    def test_includes_human_replies(self, mock_get):
+        mock_get.return_value.json.return_value = [
+            {
+                "id": 1,
+                "user": {"login": "github-actions[bot]"},
+                "body": "Use f-strings",
+                "path": "src/main.py",
+                "line": 5,
+            },
+            {
+                "id": 10,
+                "user": {"login": "alecavallo"},
+                "body": "No aplica, usamos formato legacy",
+                "in_reply_to_id": 1,
+            },
+        ]
+        mock_get.return_value.status_code = 200
+
+        comments = _fetch_bot_comments(
+            github_token="test", repo="owner/repo", pr_number=1
+        )
+        assert len(comments) == 1
+        assert len(comments[0]["replies"]) == 1
+        assert comments[0]["replies"][0]["body"] == "No aplica, usamos formato legacy"
+
+
+# ---------------------------------------------------------------------------
+# _classify_decision
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyDecision:
+    def test_rejected_keywords(self):
+        """Rejected keywords map to 'rejected'."""
+        result = _classify_decision(
+            "Use f-strings",
+            "No aplica, usamos formato legacy por consistencia",
+        )
+        assert result == "rejected"
+
+    def test_accepted_keywords(self):
+        result = _classify_decision("Add type hints", "Buen punto, lo corrijo")
+        assert result == "accepted"
+
+    def test_acknowledged_fallback(self):
+        result = _classify_decision("Refactor this", "Lo voy a revisar")
+        assert result == "acknowledged"
+
+    def test_empty_reply_falls_to_acknowledged(self):
+        result = _classify_decision("Fix this", "")
+        assert result == "acknowledged"
+
+
+# ---------------------------------------------------------------------------
+# run — integration with Engram
+# ---------------------------------------------------------------------------
+
+
+class TestRun:
+    @patch("src.learner._fetch_bot_comments")
+    def test_stores_rejected_decisions_in_engram(self, mock_fetch):
+        mock_fetch.return_value = [
+            {
+                "id": 1,
+                "user": {"login": "github-actions[bot]"},
+                "body": "Use f-strings instead of percent formatting",
+                "path": "src/main.py",
+                "line": 5,
+                "replies": [
+                    {"user": {"login": "alecavallo"}, "body": "No aplica"}
+                ],
+            },
+        ]
+
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run(
+                github_token="test",
+                repo="owner/repo",
+                pr_number=42,
+                engram_dir=tmp,
+                llm_client=None,
+            )
+            assert result["stored"] == 1
+            assert observation_count(tmp, "owner/repo") == 1
+
+    @patch("src.learner._fetch_bot_comments")
+    def test_skips_comments_without_replies(self, mock_fetch):
+        mock_fetch.return_value = [
+            {
+                "id": 1,
+                "user": {"login": "github-actions[bot]"},
+                "body": "Use f-strings",
+                "path": "src/main.py",
+                "line": 5,
+                "replies": [],
+            },
+        ]
+
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run(
+                github_token="test",
+                repo="owner/repo",
+                pr_number=42,
+                engram_dir=tmp,
+                llm_client=None,
+            )
+            assert result["stored"] == 0

--- a/test/test_review_formatter.py
+++ b/test/test_review_formatter.py
@@ -9,200 +9,139 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-import json
+"""Tests for structured review summary in review_formatter.py."""
 
-from src.review_formatter import filter_by_severity, format_review_comment
+from src.review_formatter import _parse_diff_stats, build_review_summary
 
 
-class TestFilterBySeverity:
-    """Test severity filtering logic."""
+# ---------------------------------------------------------------------------
+# _parse_diff_stats
+# ---------------------------------------------------------------------------
 
-    def test_filter_critical_only(self):
-        """Test that CRITICAL filter only includes critical items."""
+
+class TestParseDiffStats:
+    def test_empty_diff(self):
+        assert _parse_diff_stats("") == {"additions": 0, "deletions": 0, "files": 0}
+
+    def test_additions_and_deletions(self):
+        diff = """--- a/a.py
++++ b/a.py
+@@ -1 +1,2 @@
+ old
++new line
++another new
+-removed line"""
+        stats = _parse_diff_stats(diff)
+        assert stats["additions"] == 2
+        assert stats["deletions"] == 1
+
+    def test_files_counted(self):
+        diff = """--- a/a.py
++++ b/b.py
+@@ -1 +1,2 @@
++added
+--- a/c.py
++++ b/d.py
+@@ -1 +1,2 @@
++added"""
+        stats = _parse_diff_stats(diff)
+        assert stats["files"] == 2
+
+    def test_no_changes(self):
+        diff = """--- a/a.py
++++ b/a.py
+@@ -1 +1 @@
+ same"""
+        stats = _parse_diff_stats(diff)
+        assert stats["additions"] == 0
+        assert stats["deletions"] == 0
+
+
+# ---------------------------------------------------------------------------
+# build_review_summary
+# ---------------------------------------------------------------------------
+
+
+class TestBuildReviewSummary:
+    def test_mixed_severities(self):
         items = [
-            {"file": "a.py", "line": 1, "severity": "critical", "comment": "Security issue"},
-            {"file": "b.py", "line": 2, "severity": "important", "comment": "Logic error"},
-            {"file": "c.py", "line": 3, "severity": "trivial", "comment": "Style issue"},
+            {"severity": "critical", "comment": "SQL injection"},
+            {"severity": "critical", "comment": "Null pointer"},
+            {"severity": "important", "comment": "Wrong logic"},
+            {"severity": "trivial", "comment": "Unused import"},
         ]
-        result = filter_by_severity(items, "critical")
-        assert len(result) == 1
-        assert result[0]["severity"] == "critical"
+        result = build_review_summary(items, {"additions": 50, "deletions": 30, "files": 2})
+        assert "📋 Review:" in result
+        assert "+50 / -30" in result
+        assert "2 archivos" in result
+        assert "🔴" in result
+        assert "🟡" in result
+        assert "🔵" in result
 
-    def test_filter_important_includes_critical(self):
-        """Test that IMPORTANT filter includes both important and critical."""
+    def test_only_important(self):
         items = [
-            {"file": "a.py", "line": 1, "severity": "critical", "comment": "Security issue"},
-            {"file": "b.py", "line": 2, "severity": "important", "comment": "Logic error"},
-            {"file": "c.py", "line": 3, "severity": "trivial", "comment": "Style issue"},
+            {"severity": "important", "comment": "Bug"},
+            {"severity": "important", "comment": "Performance"},
         ]
-        result = filter_by_severity(items, "important")
-        assert len(result) == 2
-        assert {item["severity"] for item in result} == {"critical", "important"}
+        result = build_review_summary(items, {"additions": 10, "deletions": 5, "files": 1})
+        assert "🔴" not in result
+        assert "🟡" in result
+        assert "🔵" not in result
 
-    def test_filter_trivial_includes_all(self):
-        """Test that TRIVIAL filter includes all items."""
-        items = [
-            {"file": "a.py", "line": 1, "severity": "critical", "comment": "Security issue"},
-            {"file": "b.py", "line": 2, "severity": "important", "comment": "Logic error"},
-            {"file": "c.py", "line": 3, "severity": "trivial", "comment": "Style issue"},
-        ]
-        result = filter_by_severity(items, "trivial")
-        assert len(result) == 3
+    def test_no_items(self):
+        result = build_review_summary([], {"additions": 0, "deletions": 0, "files": 0})
+        assert "✅ No se encontraron issues" in result
 
-    def test_filter_case_insensitive(self):
-        """Test that severity filtering is case-insensitive."""
-        items = [
-            {"file": "a.py", "line": 1, "severity": "critical", "comment": "Issue"},
-        ]
-        result = filter_by_severity(items, "CRITICAL")
-        assert len(result) == 1
+    def test_single_critical(self):
+        items = [{"severity": "critical", "comment": "Security hole"}]
+        result = build_review_summary(items, {"additions": 1, "deletions": 0, "files": 1})
+        assert "🔴 1 CRITICAL" in result
+        assert "🟡" not in result
+        assert "🔵" not in result
 
-    def test_filter_unknown_severity_defaults_to_important(self):
-        """Test that unknown severity threshold defaults to important."""
-        items = [
-            {"file": "a.py", "line": 1, "severity": "critical", "comment": "Issue"},
-            {"file": "b.py", "line": 2, "severity": "trivial", "comment": "Style"},
-        ]
-        result = filter_by_severity(items, "unknown_level")
-        assert len(result) == 1  # Only critical passes important threshold
+    def test_without_diff_stats(self):
+        items = [{"severity": "important", "comment": "Bug"}]
+        result = build_review_summary(items)
+        assert "📋 Review" in result
+        assert "no stats provided" not in result.lower()
 
-    def test_filter_empty_list(self):
-        """Test filtering an empty list."""
-        result = filter_by_severity([], "critical")
-        assert not result
-
-    def test_filter_missing_severity_defaults_to_important(self):
-        """Test that items with missing severity are treated as important."""
-        items = [
-            {"file": "a.py", "line": 1, "comment": "No severity"},
-            {"file": "b.py", "line": 2, "severity": "trivial", "comment": "Style"},
-        ]
-        result = filter_by_severity(items, "important")
-        assert len(result) == 1  # Item without severity is treated as important
-
-    def test_filter_unrecognized_item_severity_defaults_to_important(self):
-        """Test that items with unrecognized severity strings default to important."""
-        items = [
-            {"file": "a.py", "line": 1, "severity": "unknown_severity", "comment": "Issue 1"},
-            {"file": "b.py", "line": 2, "severity": "typo", "comment": "Issue 2"},
-            {"file": "c.py", "line": 3, "severity": "trivial", "comment": "Style"},
-            {"file": "d.py", "line": 4, "severity": "critical", "comment": "Bug"},
-        ]
-
-        # With threshold=critical, only critical and unknown (treated as important) should not pass
-        result = filter_by_severity(items, "critical")
-        assert len(result) == 1  # Only critical item
-        assert result[0]["file"] == "d.py"
-
-        # With threshold=important, critical and unknown (defaulting to important) pass
-        result = filter_by_severity(items, "important")
-        assert len(result) == 3  # critical + 2 unknown items (treated as important)
-        file_names = {item["file"] for item in result}
-        assert file_names == {"a.py", "b.py", "d.py"}
-
-        # With threshold=trivial, all items pass
-        result = filter_by_severity(items, "trivial")
-        assert len(result) == 4
+    def test_filtered_items_only_include_severity(self):
+        """Items without severity are treated as important."""
+        items = [{"severity": "critical", "comment": "X"}, {"comment": "Y"}]
+        result = build_review_summary(items, {"additions": 10, "deletions": 0, "files": 1})
+        assert "🔴 1 CRITICAL" in result
+        assert "🟡 1 IMPORTANT" in result
 
 
-class TestFormatReviewComment:
-    def test_single_chunk_with_valid_json(self):
-        items = [{"file": "a.py", "line": 10, "severity": "critical", "comment": "Bug found"}]
-        chunk = json.dumps(items)
-        result = format_review_comment(summarized_review="Summary", chunked_reviews=[chunk], min_severity="trivial")
-        assert "**[CRITICAL]**" in result
-        assert "`a.py:10`" in result
-        assert "Bug found" in result
+# ---------------------------------------------------------------------------
+# Integration with format_review_comment
+# ---------------------------------------------------------------------------
 
-    def test_single_chunk_fallback_to_raw_text(self):
-        raw = "This is plain text review."
-        result = format_review_comment(summarized_review="Summary", chunked_reviews=[raw], min_severity="trivial")
-        assert result == raw
 
-    def test_multiple_chunks_with_valid_json(self):
-        chunk1 = json.dumps([{"file": "a.py", "line": 1, "severity": "trivial", "comment": "Style"}])
-        chunk2 = json.dumps([{"file": "b.py", "line": 2, "severity": "important", "comment": "Logic error"}])
+class TestFormatReviewCommentWithSummary:
+    def test_summary_prepended(self):
+        from src.review_formatter import format_review_comment
+
         result = format_review_comment(
-            summarized_review="Summary",
-            chunked_reviews=[chunk1, chunk2],
+            summarized_review="Summary text",
+            chunked_reviews=[
+                '[{"file": "a.py", "line": 1, "severity": "critical", "comment": "X"}]'
+            ],
+            min_severity="trivial",
+            diff="--- a/a.py\n+++ b/a.py\n@@ -1 +1,2 @@\n+new\n",
+        )
+        assert "📋 Review:" in result
+        assert "🔴 1 CRITICAL" in result
+
+    def test_summary_not_added_when_no_diff_provided(self):
+        from src.review_formatter import format_review_comment
+
+        result = format_review_comment(
+            summarized_review="Summary text",
+            chunked_reviews=[
+                '[{"file": "a.py", "line": 1, "severity": "critical", "comment": "X"}]'
+            ],
             min_severity="trivial",
         )
-        assert "<details>" in result
-        assert "Summary" in result
-        assert "**[TRIVIAL]**" in result
-        assert "**[IMPORTANT]**" in result
-
-    def test_multiple_chunks_fallback_to_raw(self):
-        result = format_review_comment(
-            summarized_review="Summary",
-            chunked_reviews=["plain text 1", "plain text 2"],
-            min_severity="trivial",
-        )
-        assert "<details>" in result
-        assert "plain text 1" in result
-        assert "plain text 2" in result
-
-    def test_empty_chunks_returns_summary(self):
-        result = format_review_comment(summarized_review="Summary", chunked_reviews=[], min_severity="trivial")
-        assert result == "Summary"
-
-    def test_file_level_comment_no_line(self):
-        items = [{"file": "a.py", "line": 0, "severity": "trivial", "comment": "Consider refactoring"}]
-        chunk = json.dumps(items)
-        result = format_review_comment(summarized_review="Summary", chunked_reviews=[chunk], min_severity="trivial")
-        assert "`a.py`" in result
-        assert "a.py:0" not in result
-
-    def test_empty_json_array_falls_back_to_summary(self):
-        result = format_review_comment(summarized_review="Summary", chunked_reviews=["[]"], min_severity="trivial")
-        assert result == "Summary"
-
-    def test_severity_filtering_critical(self):
-        """Test that only critical items are included when filter is CRITICAL."""
-        items = [
-            {"file": "a.py", "line": 1, "severity": "critical", "comment": "Security issue"},
-            {"file": "b.py", "line": 2, "severity": "important", "comment": "Logic error"},
-            {"file": "c.py", "line": 3, "severity": "trivial", "comment": "Style issue"},
-        ]
-        chunk = json.dumps(items)
-        result = format_review_comment(summarized_review="Summary", chunked_reviews=[chunk], min_severity="critical")
-        assert "**[CRITICAL]**" in result
-        assert "**[IMPORTANT]**" not in result
-        assert "**[TRIVIAL]**" not in result
-
-    def test_severity_filtering_important(self):
-        """Test that important and critical items are included when filter is IMPORTANT."""
-        items = [
-            {"file": "a.py", "line": 1, "severity": "critical", "comment": "Security issue"},
-            {"file": "b.py", "line": 2, "severity": "important", "comment": "Logic error"},
-            {"file": "c.py", "line": 3, "severity": "trivial", "comment": "Style issue"},
-        ]
-        chunk = json.dumps(items)
-        result = format_review_comment(summarized_review="Summary", chunked_reviews=[chunk], min_severity="important")
-        assert "**[CRITICAL]**" in result
-        assert "**[IMPORTANT]**" in result
-        assert "**[TRIVIAL]**" not in result
-
-    def test_severity_filtering_trivial(self):
-        """Test that all items are included when filter is TRIVIAL."""
-        items = [
-            {"file": "a.py", "line": 1, "severity": "critical", "comment": "Security issue"},
-            {"file": "b.py", "line": 2, "severity": "important", "comment": "Logic error"},
-            {"file": "c.py", "line": 3, "severity": "trivial", "comment": "Style issue"},
-        ]
-        chunk = json.dumps(items)
-        result = format_review_comment(summarized_review="Summary", chunked_reviews=[chunk], min_severity="trivial")
-        assert "**[CRITICAL]**" in result
-        assert "**[IMPORTANT]**" in result
-        assert "**[TRIVIAL]**" in result
-
-    def test_all_items_filtered_returns_summary(self):
-        """Test that when all items are filtered, summary is returned."""
-        items = [
-            {"file": "a.py", "line": 1, "severity": "trivial", "comment": "Style"},
-            {"file": "b.py", "line": 2, "severity": "important", "comment": "Logic"},
-        ]
-        chunk = json.dumps(items)
-        result = format_review_comment(summarized_review="Summary", chunked_reviews=[chunk], min_severity="critical")
-        # When all items filtered out and single chunk, should return summary
-        assert result == "Summary"
+        # Without diff param, backward compatible — no summary
+        assert "📋 Review:" not in result

--- a/test/test_review_formatter.py
+++ b/test/test_review_formatter.py
@@ -168,3 +168,17 @@ class TestFormatReviewCommentWithSummary:
         # The fallback should have parsed summarized_review
         assert "TRIVIAL" in result
         assert "a.py" in result
+
+    def test_clean_message_when_no_issues(self):
+        """When there are no valid items, show a clean message instead of raw JSON."""
+        from src.review_formatter import format_review_comment
+
+        result = format_review_comment(
+            summarized_review='[]',
+            chunked_reviews=['[]'],
+            min_severity="important",
+        )
+        assert "✅" in result
+        assert "no issues found" in result.lower()
+        assert "IMPORTANT" in result
+        assert result.strip().startswith("✅")

--- a/test/test_review_formatter.py
+++ b/test/test_review_formatter.py
@@ -145,3 +145,26 @@ class TestFormatReviewCommentWithSummary:
         )
         # Without diff param, backward compatible — no summary
         assert "📋 Review:" not in result
+
+    def test_fallback_parses_summarized_review_json(self):
+        """When items fail validation but summarized_review has valid JSON,
+        the fallback in any_parsed branch should parse and format them."""
+        from src.review_formatter import format_review_comment
+        from src.review_parser import _validate_review_item
+
+        # Craft JSON that's valid but items fail validation (empty comment)
+        chunk = '[{"file": "a.py", "line": 1, "severity": "trivial", "comment": ""}]'
+        # Verify items are invalid on their own
+        import json
+        assert _validate_review_item(json.loads(chunk)[0]) is None
+
+        # summarized_review has the same items, but shorter
+        result = format_review_comment(
+            summarized_review='[{"file": "a.py", "line": 1, "severity": "trivial", "comment": "X"}]',
+            chunked_reviews=[chunk],
+            min_severity="trivial",
+        )
+        # Without diff param, no summary header
+        # The fallback should have parsed summarized_review
+        assert "TRIVIAL" in result
+        assert "a.py" in result


### PR DESCRIPTION
## Resumen

Cuando un PR se cierra, el action ahora analiza las discusiones humanas sobre los comentarios del bot y persiste las decisiones en Engram. Esto cierra el loop: cada "no aplica" humano alimenta la memoria del bot.

## Cómo funciona

```
PR mergeado/cerrado
  ↓
workflows/learn-from-pr.yml se dispara
  ↓
src/learner.py:
  1. Fetch todos los review comments del bot
  2. Busca respuestas humanas (in_reply_to)
  3. Clasifica: rejected / accepted / acknowledged
  4. Store en Engram
  ↓
Próximo PR → bot consulta Engram → no repite
```

## Clasificación

Por ahora usa keyword-based matching (sin llamada extra a Gemini):

| Respuesta humana | Clasificación |
|-----------------|---------------|
| "no aplica", "falso", "wont fix", "ya se hace eso" | **rejected** |
| "good catch", "fixed", "gracias", "buen punto" | **accepted** |
| cualquier otra | **acknowledged** |

Futuro: usar Gemini para clasificación más precisa (prompt de ~200 tokens por decisión).

## Cambios

- 🆕 `src/learner.py` — fetch, clasificación, persistencia
- 🆕 `.github/workflows/learn-from-pr.yml` — trigger en PR closed
- 🔄 `action.yml` — nuevo input `mode` (review\|learn)
- 🔄 `src/main.py` — dispatch a learner si mode=learn
- 🧪 12 tests nuevos (fetch, classify, integration con Engram)
- 📋 `specs/post-pr-learning.md` — spec detallado

## No-rompimiento

- `mode` default es `review` — comportamiento existente no cambia
- El workflow learn-from-pr es opt-in (hay que agregarlo al repo)