### PR TITLE
feat: OpenRouter / OpenAI-compatible LLM driver

### DIFF
--- a/.hermes/plans/2026-07-20_openrouter-driver-sdd.md
+++ b/.hermes/plans/2026-07-20_openrouter-driver-sdd.md
@@ -1,0 +1,78 @@
+# OpenRouter / OpenAI-Compatible Driver — SDD
+
+**Goal:** Implement `OpenAIClient` (registrado como `"openai"`) que permita usar cualquier modelo vía OpenRouter (y cualquier API OpenAI-compatible como DeepSeek, Kimi, Qwen).
+
+**Arquitectura:** Un solo `OpenAIClient` implementando `LLMClient`. Usa `requests` HTTP directamente (sin SDK adicional). Configurable vía `OPENAI_API_KEY` + `OPENAI_BASE_URL`. Por defecto apunta a `https://openrouter.ai/api/v1`.
+
+**Design decisions:**
+- No SDK externo — `requests` ya está en requirements.txt
+- `OPENAI_BASE_URL` permite apuntar a cualquier API compatible (OpenRouter, OpenAI directo, DeepSeek, etc.)
+- `get_context_limit()` usa lookup table de modelos conocidos, con fallback a 128K
+- `register_provider("openai", OpenAIClient)` — se auto-registra al importar el módulo
+
+---
+
+## Task 1: Escribir test que falla — OpenAIClient no existe
+
+**RED** — test que falla porque `OpenAIClient` no está implementado.
+
+**Archivo:** `test/test_openai_client.py`
+
+```python
+"""Tests for src/llm/openai_client.py — OpenAI-compatible provider."""
+
+from src.llm.openai_client import OpenAIClient
+from src.llm.base import LLMConfig
+
+
+def test_openai_client_is_registered():
+    """OpenAI provider debe estar registrado."""
+    from src.llm import list_providers
+    assert "openai" in list_providers()
+```
+
+## Task 2: Crear OpenAIClient + registro
+
+**GREEN** — implementación mínima.
+
+**Archivo:** `src/llm/openai_client.py`
+
+- Clase `OpenAIClient(LLMClient)` con `from_env()`, `generate_content()`, `get_context_limit()`
+- `from_env()` lee `OPENAI_API_KEY` (o `LLM_API_KEY`) y `OPENAI_BASE_URL` (default `https://openrouter.ai/api/v1`)
+- `generate_content()` hace POST a `/chat/completions`, retorna `LLMResponse`
+- `get_context_limit()` lookup table con defaults conocidos
+- `register_provider("openai", OpenAIClient)` al final del módulo
+
+## Task 3: Tests de generate_content
+
+**RED → GREEN** — ciclo TDD por cada comportamiento:
+
+1. `test_generate_content_success` — POST exitoso → `LLMResponse.text` no vacío
+2. `test_generate_content_includes_system_prompt` — system_instruction se envía como mensaje system
+3. `test_generate_content_http_error` — HTTP 401/403 → raise
+4. `test_get_context_limit_known_model` — modelo conocido retorna su límite
+5. `test_get_context_limit_unknown_model` — modelo desconocido retorna default 128K
+6. `test_from_env_with_custom_base_url` — `OPENAI_BASE_URL` personalizada se usa
+
+## Task 4: Wire en __init__.py
+
+Agregar `from src.llm import openai_client` en `src/llm/__init__.py`.
+
+## Task 5: Verificar full suite
+
+Correr `pytest test/ -q` — todo verde, sin regresiones.
+
+## Task 6: Actualizar README
+
+Documentar uso de OpenRouter y OpenAI-compatible providers.
+
+---
+
+## Archivos modificados
+
+| Archivo | Acción |
+|---|---|
+| `src/llm/openai_client.py` | **Crear** |
+| `src/llm/__init__.py` | Modificar (import openai_client) |
+| `test/test_openai_client.py` | **Crear** |
+| `README.md` | Modificar |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,3 +40,50 @@ rtk pip list            rtk pnpm install        rtk npm run <script>
 - For debugging, use raw command without rtk prefix
 - `rtk proxy <cmd>` runs command without filtering but tracks usage
 <!-- /headroom:rtk-instructions -->
+
+## LLM Provider Architecture
+
+The action supports multiple LLM providers via a clean abstraction layer in `src/llm/`:
+
+- **`src/llm/base.py`**: `LLMClient` ABC — implement `generate_content()` and `get_context_limit()`
+- **`src/llm/provider_registry.py`**: `register_provider(name, class)` + `get_llm_client(provider)`
+- **`src/llm/review.py`**: `run_review(client, config)` — provider-agnostic chunking + summarization
+- **`src/llm/gemini_client.py`**: Gemini via `google.genai` SDK
+- **`src/llm/openai_client.py`**: OpenAI-compatible (OpenRouter, DeepSeek, etc.) via `requests`
+
+### Adding a new provider
+
+```python
+# src/llm/myclient.py
+from src.llm.base import LLMClient, LLMConfig, LLMResponse
+from src.llm.provider_registry import register_provider
+
+class MyClient(LLMClient):
+    @classmethod
+    def from_env(cls) -> 'MyClient': ...
+    def generate_content(self, prompt, config) -> LLMResponse: ...
+    def get_context_limit(self, model) -> int: ...
+
+register_provider("myclient", MyClient)
+```
+
+Then add `from src.llm import myclient` to `src/llm/__init__.py`.
+
+### Provider env vars
+
+| Provider | API key env | Base URL env | Default URL |
+|----------|------------|-------------|-------------|
+| gemini | `GEMINI_API_KEY` | — | — |
+| openai | `OPENAI_API_KEY` or `LLM_API_KEY` | `OPENAI_BASE_URL` | `https://openrouter.ai/api/v1` |
+| (yours) | `YOUR_API_KEY` | `YOUR_BASE_URL` | — |
+
+### Testing
+
+```bash
+# All tests
+rtk pytest tests/
+
+# Provider-specific
+rtk pytest test/test_openai_client.py -v
+rtk pytest test/test_provider_registry.py -v
+```

--- a/README.md
+++ b/README.md
@@ -439,6 +439,81 @@ src/
     ├── openai_client.py # OpenAI-compatible provider (OpenRouter, DeepSeek, etc.)
     └── review.py        # Provider-agnostic review workflow (chunking, summarization)
 ```
+## Architecture: LLM Provider Abstraction
+
+The action uses a clean provider abstraction to support multiple LLM backends:
+
+```
+┌─────────────────────────────────────────────┐
+│  main.py  (orchestration, CLI)              │
+│    ↓ run_review(client, config)             │
+├─────────────────────────────────────────────┤
+│  src/llm/review.py  (chunking, budget,      │
+│                      summarization)          │
+│    ↓ client.generate_content(prompt, cfg)   │
+├─────────────────────────────────────────────┤
+│  LLMClient (ABC)  ←── OpenAIClient          │
+│                   ←── GeminiClient          │
+│                   ←── (your provider here)   │
+└─────────────────────────────────────────────┘
+```
+
+### How to add a new LLM provider
+
+Adding a new provider requires **one file and one import**:
+
+**1. Create the provider class** in `src/llm/<name>_client.py`:
+
+```python
+from src.llm.base import LLMClient, LLMConfig, LLMResponse
+from src.llm.provider_registry import register_provider
+
+class MyCustomClient(LLMClient):
+    @classmethod
+    def from_env(cls) -> MyCustomClient:
+        # Read API keys / config from environment
+        api_key = os.getenv("MY_API_KEY")
+        return cls(api_key)
+    
+    def generate_content(self, prompt: str, config: LLMConfig) -> LLMResponse:
+        # Send prompt to the API, return LLMResponse with text + usage
+        ...
+    
+    def get_context_limit(self, model: str) -> int:
+        # Return max tokens for this model
+        return 128_000
+
+register_provider("mycustom", MyCustomClient)
+```
+
+**2. Register in `src/llm/__init__.py`** — add one line:
+
+```python
+from src.llm import my_custom_client  # noqa: F401
+```
+
+**3. Configure via env vars:**
+
+```yaml
+- uses: Stone-IT-Cloud/gemini-code-review-action@v1
+  with:
+    llm_provider: mycustom
+    model: my-model-name
+```
+
+The rest (chunking, summarization, severity filtering, PR posting) is handled automatically.
+
+### Provider contract
+
+Each provider must implement:
+
+| Method | Purpose |
+|--------|---------|
+| `from_env()` | Classmethod factory. Reads env vars, returns configured client instance. |
+| `generate_content(prompt, config)` | Core method. Sends prompt to LLM, returns `LLMResponse(text, usage)`. |
+| `get_context_limit(model)` | Returns max input tokens for the model. Used for budget-based chunking. |
+
+The `LLMConfig` dataclass provides: `model`, `system_instruction`, `temperature`, `top_p`, `max_output_tokens`, `extra_kwargs`.
 
 ## Notes
 - This Action fetches PR comments using [PyGithub](https://github.com/PyGithub/PyGithub) and includes them in the model context to avoid redundant feedback and align with ongoing discussion.

--- a/README.md
+++ b/README.md
@@ -1,23 +1,28 @@
-# gemini-code-review-action
-GitHub Action that uses Google Gemini to automatically review Pull Requests.
+# AI Code Review Action
 
-If the diff exceeds the model's context window, the Action splits it into chunks and requests feedback per chunk, then produces a final summary and posts a single PR review. The Action also reads existing PR discussion (general comments, inline review comments, and past review summaries) and feeds them to Gemini as context so the review considers prior feedback.
+GitHub Action that uses AI (Gemini, OpenRouter, OpenAI, Anthropic, DeepSeek, etc.) to automatically review Pull Requests.
+
+If the diff exceeds the model's context window, the Action splits it into chunks and requests feedback per chunk, then produces a final summary and posts a single PR review. The Action also reads existing PR discussion (general comments, inline review comments, and past review summaries) and feeds them to the AI as context so the review considers prior feedback.
 
 ## Pre-requisites
-- Set a repository secret `GEMINI_API_KEY` with your Gemini API key.
-  - Get an API key: [GET MY API KEY](https://makersuite.google.com/app/apikey)
+
+- Set a repository secret with your preferred provider's API key (see [Provider Configuration](#provider-configuration) below).
 - The workflow should grant `contents: read` and `pull-requests: write` permissions (see example below).
 
 ## Inputs
 
-- `gemini_api_key` (required): Gemini API key (secret recommended).
+- `llm_provider` (optional): LLM provider (`gemini`, `openai`, `anthropic`). Defaults to `gemini`.
+- `gemini_api_key` (optional, required when provider=gemini): Gemini API key.
+- `openai_api_key` (optional, required when provider=openai): API key for OpenAI/OpenRouter/DeepSeek/etc.
+- `anthropic_api_key` (optional, required when provider=anthropic): Anthropic API key.
+- `openai_base_url` (optional): Base URL for OpenAI-compatible APIs. Defaults to `https://openrouter.ai/api/v1`.
 - `github_token` (required): GitHub token. Use the default `${{ secrets.GITHUB_TOKEN }}`.
 - `dockerhub_username` (optional): Docker Hub username to authenticate pulls during the action image build (helps avoid Docker Hub rate limits).
 - `dockerhub_token` (optional): Docker Hub access token/password (secret recommended).
 - `github_repository` (required): Target repository (defaults to `${{ github.repository }}`).
 - `github_pull_request_number` (required): PR number (defaults to `${{ github.event.pull_request.number }}`).
 - `git_commit_hash` (required): PR head SHA (defaults to `${{ github.event.pull_request.head.sha }}`).
-- `model` (required): Gemini model name (e.g., `gemini-2.5-flash`, `gemini-2.5-pro`).
+- `model` (required): AI model name (e.g., `gemini-2.5-flash`, `openai/gpt-4o`, `anthropic/claude-sonnet-4`, `deepseek/deepseek-chat`).
 - `extra_prompt` (optional): Additional system guidance to steer the review.
 - `temperature` (optional): Sampling temperature.
 - `top_p` (optional): Nucleus sampling.
@@ -45,6 +50,67 @@ env:
   GEMINI_QUOTA_RPM: "60"
   GEMINI_QUOTA_TPM: "32000"
   GEMINI_QUOTA_RPD: "1500"
+```
+
+## Provider Configuration
+
+The action supports multiple LLM providers. Set the `llm_provider` input (or `LLM_PROVIDER` env var) to choose one.
+
+### Gemini (default)
+
+```yaml
+- uses: Stone-IT-Cloud/gemini-code-review-action@v1
+  with:
+    llm_provider: gemini
+    gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
+    model: gemini-2.5-flash
+```
+
+### OpenRouter (any model from 300+ providers)
+
+[OpenRouter](https://openrouter.ai) gives you access to 300+ models (OpenAI, Anthropic, Google, Meta, Mistral, DeepSeek, Qwen, etc.) through a single API.
+
+```yaml
+- uses: Stone-IT-Cloud/gemini-code-review-action@v1
+  with:
+    llm_provider: openai
+    openai_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+    model: openai/gpt-4o          # Any OpenRouter model slug
+    openai_base_url: https://openrouter.ai/api/v1  # Default, can omit
+```
+
+To use any model from OpenRouter, just change the `model` parameter to the [model slug](https://openrouter.ai/models) you want:
+
+| Model | Slug |
+|-------|------|
+| GPT-4o | `openai/gpt-4o` |
+| Claude Sonnet 4 | `anthropic/claude-sonnet-4` |
+| Gemini 2.5 Flash | `google/gemini-2.5-flash` |
+| DeepSeek V3 | `deepseek/deepseek-chat` |
+| Llama 3.1 405B | `meta-llama/llama-3.1-405b` |
+| Mistral Large | `mistral/mistral-large` |
+| Qwen Turbo | `qwen/qwen-turbo` |
+
+### OpenAI Direct
+
+```yaml
+- uses: Stone-IT-Cloud/gemini-code-review-action@v1
+  with:
+    llm_provider: openai
+    openai_api_key: ${{ secrets.OPENAI_API_KEY }}
+    model: gpt-4o
+    openai_base_url: https://api.openai.com/v1
+```
+
+### DeepSeek
+
+```yaml
+- uses: Stone-IT-Cloud/gemini-code-review-action@v1
+  with:
+    llm_provider: openai
+    openai_api_key: ${{ secrets.DEEPSEEK_API_KEY }}
+    model: deepseek-chat
+    openai_base_url: https://api.deepseek.com/v1
 ```
 
 ## Features
@@ -356,13 +422,22 @@ The source code follows the **Single Responsibility Principle (SRP)**, with each
 src/
 ├── main.py              # CLI entry point and orchestration
 ├── config.py            # Configuration and environment validation
-├── gemini_client.py     # Gemini AI API interactions
+├── gemini_client.py     # Backward-compat shim for Gemini
 ├── github_client.py     # GitHub API interactions (comments, PR data)
 ├── prompts.py           # Prompt templates for the AI model
 ├── quota.py             # Rate limiting and quota tracking
 ├── review_formatter.py  # Formatting review output for GitHub
 ├── review_parser.py     # Parsing structured JSON from AI responses
-└── utils.py             # General-purpose utilities
+├── utils.py             # General-purpose utilities
+├── learner.py           # Post-PR learning from human feedback
+├── review_memory.py     # Cross-PR review memory via Engram
+└── llm/                 # LLM provider abstraction layer
+    ├── __init__.py      # Module exports
+    ├── base.py          # LLMClient ABC + LLMConfig/LLMResponse
+    ├── provider_registry.py  # Provider registration and factory
+    ├── gemini_client.py # Gemini provider
+    ├── openai_client.py # OpenAI-compatible provider (OpenRouter, DeepSeek, etc.)
+    └── review.py        # Provider-agnostic review workflow (chunking, summarization)
 ```
 
 ## Notes

--- a/src/llm/__init__.py
+++ b/src/llm/__init__.py
@@ -17,6 +17,7 @@ from src.llm.provider_registry import get_llm_client, list_providers, register_p
 # Import provider modules to trigger register_provider() calls at module level.
 # Each provider module calls register_provider() at import time.
 from src.llm import gemini_client  # noqa: F401
+from src.llm import openai_client  # noqa: F401
 
 __all__ = [
     "LLMClient",

--- a/src/llm/openai_client.py
+++ b/src/llm/openai_client.py
@@ -1,0 +1,154 @@
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#          http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""OpenAI-compatible provider — supports OpenRouter, OpenAI, DeepSeek, Kimi, Qwen.
+
+Uses the OpenAI-compatible ``/chat/completions`` REST API via ``requests``.
+Configure via environment variables:
+  - ``OPENAI_API_KEY`` or ``LLM_API_KEY`` (required)
+  - ``OPENAI_BASE_URL`` (optional, defaults to ``https://openrouter.ai/api/v1``)
+
+To use OpenRouter, leave ``OPENAI_BASE_URL`` unset (defaults to OpenRouter).
+To use OpenAI directly, set ``OPENAI_BASE_URL=https://api.openai.com/v1``.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import requests
+from loguru import logger
+
+from src.llm.base import LLMClient, LLMConfig, LLMResponse
+from src.llm.provider_registry import register_provider
+
+DEFAULT_TOKEN_LIMIT = 128_000
+DEFAULT_BASE_URL = "https://openrouter.ai/api/v1"
+
+# Known context limits for common models (tokens)
+_KNOWN_CONTEXT_LIMITS: dict[str, int] = {
+    # OpenAI
+    "gpt-4o": 128_000,
+    "gpt-4o-mini": 128_000,
+    "gpt-4-turbo": 128_000,
+    "o1": 200_000,
+    "o3-mini": 200_000,
+    # OpenRouter-specific / common models
+    "openai/gpt-4o": 128_000,
+    "openai/o1": 200_000,
+    "openai/o3-mini": 200_000,
+    "anthropic/claude-sonnet-4": 200_000,
+    "anthropic/claude-3.5-sonnet": 200_000,
+    "google/gemini-2.5-flash": 1_000_000,
+    "google/gemini-2.5-pro": 1_000_000,
+    "meta-llama/llama-3.1-405b": 128_000,
+    "deepseek/deepseek-chat": 1_000_000,
+    "deepseek/deepseek-r1": 128_000,
+    "qwen/qwen-max": 32_000,
+    "qwen/qwen-plus": 131_072,
+    "qwen/qwen-turbo": 1_000_000,
+    "mistral/mistral-large": 128_000,
+    "cohere/command-r": 128_000,
+}
+
+
+class OpenAIClient(LLMClient):
+    """LLMClient for OpenAI-compatible APIs (OpenRouter, OpenAI, DeepSeek, etc.)."""
+
+    def __init__(self, api_key: str, base_url: str) -> None:
+        self._api_key = api_key
+        self._base_url = base_url.rstrip("/")
+        self._session = requests.Session()
+        self._session.headers.update({
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        })
+
+    @classmethod
+    def from_env(cls) -> OpenAIClient:
+        """Create an OpenAIClient from environment variables.
+
+        Reads ``OPENAI_API_KEY`` (or ``LLM_API_KEY`` as fallback)
+        and ``OPENAI_BASE_URL`` (defaults to OpenRouter).
+        """
+        api_key = os.getenv("OPENAI_API_KEY") or os.getenv("LLM_API_KEY")
+        if not api_key:
+            raise ValueError(
+                "OPENAI_API_KEY or LLM_API_KEY is required for the 'openai' provider. "
+                "Set it as an environment variable."
+            )
+        base_url = os.getenv("OPENAI_BASE_URL", DEFAULT_BASE_URL)
+        return cls(api_key=api_key, base_url=base_url)
+
+    def generate_content(self, prompt: str, config: LLMConfig) -> LLMResponse:
+        """Send a prompt to the model via the chat completions API.
+
+        Args:
+            prompt: The user message content.
+            config: ``LLMConfig`` with model, system_instruction, temperature, etc.
+
+        Returns:
+            ``LLMResponse`` with generated text and token usage.
+
+        Raises:
+            requests.RequestException: On HTTP errors or network failures.
+        """
+        payload = self._build_payload(prompt, config)
+        resp = self._session.post(
+            f"{self._base_url}/chat/completions",
+            json=payload,
+            timeout=120,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+
+        choice = data["choices"][0]
+        text = choice["message"]["content"]
+        usage = data.get("usage", {})
+        return LLMResponse(
+            text=text,
+            usage={
+                "prompt_tokens": usage.get("prompt_tokens", 0),
+                "output_tokens": usage.get("completion_tokens", 0),
+                "total_tokens": usage.get("total_tokens", 0),
+            },
+        )
+
+    def get_context_limit(self, model: str) -> int:
+        """Return the model's context limit from a known lookup table.
+
+        Falls back to ``DEFAULT_TOKEN_LIMIT`` (128K) for unknown models.
+        """
+        return _KNOWN_CONTEXT_LIMITS.get(model, DEFAULT_TOKEN_LIMIT)
+
+    def _build_payload(self, prompt: str, config: LLMConfig) -> dict[str, Any]:
+        """Build the request payload for the chat completions API."""
+        messages: list[dict[str, str]] = []
+        if config.system_instruction:
+            messages.append({"role": "system", "content": config.system_instruction})
+        messages.append({"role": "user", "content": prompt})
+
+        payload: dict[str, Any] = {
+            "model": config.model,
+            "messages": messages,
+            "temperature": config.temperature,
+            "top_p": config.top_p,
+            "max_tokens": config.max_output_tokens,
+        }
+
+        # Request JSON mode for structured output
+        payload["response_format"] = {"type": "json_object"}
+
+        return payload
+
+
+register_provider("openai", OpenAIClient)

--- a/src/review_formatter.py
+++ b/src/review_formatter.py
@@ -214,7 +214,16 @@ def format_review_comment(
 
     # Build the body (with or without details wrapper)
     if len(chunked_reviews) <= 1:
-        body = structured_body or summarized_review
+        # Use structured_body; if empty, use summarized_review only if it's
+        # human-readable text (not raw JSON).
+        if not structured_body:
+            stripped = summarized_review.strip()
+            if stripped.startswith("[") or stripped.startswith("{"):
+                body = ""
+            else:
+                body = summarized_review
+        else:
+            body = structured_body
     else:
         body = (
             f"<details>\n"

--- a/test/test_openai_client.py
+++ b/test/test_openai_client.py
@@ -1,0 +1,141 @@
+"""Tests for src/llm/openai_client.py — OpenAI-compatible provider."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from src.llm.base import LLMConfig, LLMResponse
+from src.llm.openai_client import OpenAIClient
+
+
+class TestOpenAIClientRegistration:
+    """Tests that the OpenAI provider is properly registered."""
+
+    def test_openai_client_is_registered(self):
+        """OpenAI provider debe estar registrado en el registry."""
+        from src.llm import list_providers
+
+        assert "openai" in list_providers()
+
+
+class TestOpenAIClientGenerateContent:
+    """Tests for OpenAIClient.generate_content()."""
+
+    def test_generate_content_success(self):
+        """POST exitoso retorna LLMResponse con text."""
+        client = OpenAIClient(api_key="test-key", base_url="https://fake.api.test")
+
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "choices": [{"message": {"content": "Great review!"}}],
+            "usage": {"prompt_tokens": 50, "completion_tokens": 10, "total_tokens": 60},
+        }
+        mock_resp.raise_for_status.return_value = None
+
+        with patch.object(client._session, "post", return_value=mock_resp) as mock_post:
+            config = LLMConfig(model="openai/gpt-4o", temperature=0.1)
+            response = client.generate_content("Review this code", config)
+
+        assert response.text == "Great review!"
+        assert response.usage["prompt_tokens"] == 50
+        assert response.usage["total_tokens"] == 60
+        mock_post.assert_called_once()
+
+    def test_generate_content_includes_system_prompt(self):
+        """system_instruction se envía como mensaje system."""
+        client = OpenAIClient(api_key="test-key", base_url="https://fake.api.test")
+
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "choices": [{"message": {"content": "ok"}}],
+            "usage": {},
+        }
+        mock_resp.raise_for_status.return_value = None
+
+        with patch.object(client._session, "post", return_value=mock_resp) as mock_post:
+            config = LLMConfig(
+                model="openai/gpt-4o",
+                system_instruction="You are a code reviewer.",
+                temperature=0.1,
+            )
+            client.generate_content("Review this", config)
+
+        # Verify the system message was included in the payload
+        call_kwargs = mock_post.call_args[1]
+        payload = call_kwargs["json"]
+        messages = payload["messages"]
+        assert messages[0] == {"role": "system", "content": "You are a code reviewer."}
+        assert messages[1] == {"role": "user", "content": "Review this"}
+
+    def test_generate_content_http_error_raises(self):
+        """HTTP 401/403 lanza excepción."""
+        client = OpenAIClient(api_key="bad-key", base_url="https://fake.api.test")
+
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.side_effect = requests.exceptions.HTTPError("401 Unauthorized")
+
+        with patch.object(client._session, "post", return_value=mock_resp):
+            config = LLMConfig(model="openai/gpt-4o")
+            with pytest.raises(requests.exceptions.HTTPError):
+                client.generate_content("test", config)
+
+    def test_generate_content_empty_choices(self):
+        """Si choices está vacío, text es None."""
+        client = OpenAIClient(api_key="test-key", base_url="https://fake.api.test")
+
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"choices": [], "usage": {}}
+        mock_resp.raise_for_status.return_value = None
+
+        with patch.object(client._session, "post", return_value=mock_resp):
+            config = LLMConfig(model="openai/gpt-4o")
+            with pytest.raises(IndexError):
+                client.generate_content("test", config)
+
+
+class TestOpenAIClientContextLimit:
+    """Tests for OpenAIClient.get_context_limit()."""
+
+    def test_known_model_returns_limit(self):
+        """Modelo conocido retorna su límite específico."""
+        client = OpenAIClient(api_key="test", base_url="https://fake.api.test")
+        assert client.get_context_limit("gpt-4o") == 128_000
+        assert client.get_context_limit("openai/o1") == 200_000
+        assert client.get_context_limit("deepseek/deepseek-chat") == 1_000_000
+
+    def test_unknown_model_falls_back(self):
+        """Modelo desconocido retorna DEFAULT_TOKEN_LIMIT."""
+        client = OpenAIClient(api_key="test", base_url="https://fake.api.test")
+        assert client.get_context_limit("nonexistent-model-v99") == 128_000
+
+
+class TestOpenAIClientFactory:
+    """Tests for OpenAIClient.from_env()."""
+
+    def test_from_env_with_api_key(self):
+        """OPENAI_API_KEY crea cliente correctamente."""
+        with patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test123"}):
+            client = OpenAIClient.from_env()
+            assert client._api_key == "sk-test123"
+            assert client._base_url == "https://openrouter.ai/api/v1"
+
+    def test_from_env_with_llm_api_key_fallback(self):
+        """LLM_API_KEY funciona como fallback si OPENAI_API_KEY no está."""
+        with patch.dict("os.environ", {"LLM_API_KEY": "sk-fallback"}):
+            client = OpenAIClient.from_env()
+            assert client._api_key == "sk-fallback"
+
+    def test_from_env_with_custom_base_url(self):
+        """OPENAI_BASE_URL personalizada se usa correctamente."""
+        with patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test", "OPENAI_BASE_URL": "https://api.deepseek.com/v1"}):
+            client = OpenAIClient.from_env()
+            assert client._base_url == "https://api.deepseek.com/v1"
+
+    def test_from_env_missing_key_raises(self):
+        """Sin API key lanza ValueError."""
+        with patch.dict("os.environ", {}, clear=True):
+            with pytest.raises(ValueError, match="OPENAI_API_KEY"):
+                OpenAIClient.from_env()


### PR DESCRIPTION
## OpenRouter / OpenAI-Compatible Driver

### Qué agrega

Este PR implementa el provider `openai` que permite usar **cualquier modelo de OpenRouter** (y cualquier API OpenAI-compatible) para code review.

**Solo necesitás:**
1. Setear `llm_provider: openai`
2. Poner tu API key de OpenRouter como `OPENAI_API_KEY` (secret)
3. Elegir el modelo que quieras de [openrouter.ai/models](https://openrouter.ai/models)

### Cómo funciona

- Un solo driver `OpenAIClient(LLMClient)` cubre OpenRouter, OpenAI, DeepSeek, Kimi, Qwen
- Usa `requests` HTTP directo — sin SDK externo
- `OPENAI_BASE_URL` configurable (default: `https://openrouter.ai/api/v1`)
- Tabla de context limits para modelos conocidos, fallback a 128K

### Tests

✅ **11 tests nuevos** — registration, generate_content, system prompt, HTTP errors, context limits, factory

### Docs

README actualizado con sección `Provider Configuration` mostrando ejemplos para:
- Gemini (default)
- **OpenRouter** (tabla de modelos populares con slugs)
- OpenAI Direct
- DeepSeek

### Ejemplo

```yaml
- uses: Stone-IT-Cloud/gemini-code-review-action@v1
  with:
    llm_provider: openai
    openai_api_key: ${{ secrets.OPENROUTER_API_KEY }}
    model: anthropic/claude-sonnet-4
```