### PR TITLE
feat: native OpenAI provider + OpenRouter alias

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,8 @@ Then add `from src.llm import myclient` to `src/llm/__init__.py`.
 | Provider | API key env | Base URL env | Default URL |
 |----------|------------|-------------|-------------|
 | gemini | `GEMINI_API_KEY` | — | — |
-| openai | `OPENAI_API_KEY` or `LLM_API_KEY` | `OPENAI_BASE_URL` | `https://openrouter.ai/api/v1` |
+| openai | `OPENAI_API_KEY` or `LLM_API_KEY` | `OPENAI_BASE_URL` | `https://api.openai.com/v1` |
+| openrouter | `OPENAI_API_KEY` or `LLM_API_KEY` | `OPENAI_BASE_URL` | `https://openrouter.ai/api/v1` |
 | (yours) | `YOUR_API_KEY` | `YOUR_BASE_URL` | — |
 
 ### Testing

--- a/README.md
+++ b/README.md
@@ -66,17 +66,26 @@ The action supports multiple LLM providers. Set the `llm_provider` input (or `LL
     model: gemini-2.5-flash
 ```
 
-### OpenRouter (any model from 300+ providers)
-
-[OpenRouter](https://openrouter.ai) gives you access to 300+ models (OpenAI, Anthropic, Google, Meta, Mistral, DeepSeek, Qwen, etc.) through a single API.
+### OpenAI (default for openai provider)
 
 ```yaml
 - uses: Stone-IT-Cloud/gemini-code-review-action@v1
   with:
     llm_provider: openai
+    openai_api_key: ${{ secrets.OPENAI_API_KEY }}
+    model: gpt-4o
+```
+
+### OpenRouter (any model from 300+ providers)
+
+[OpenRouter](https://openrouter.ai) gives you access to 300+ models (OpenAI, Anthropic, Google, Meta, Mistral, DeepSeek, Qwen, etc.) through a single API. Use `llm_provider: openrouter` (no need to set `openai_base_url`).
+
+```yaml
+- uses: Stone-IT-Cloud/gemini-code-review-action@v1
+  with:
+    llm_provider: openrouter
     openai_api_key: ${{ secrets.OPENROUTER_API_KEY }}
     model: openai/gpt-4o          # Any OpenRouter model slug
-    openai_base_url: https://openrouter.ai/api/v1  # Default, can omit
 ```
 
 To use any model from OpenRouter, just change the `model` parameter to the [model slug](https://openrouter.ai/models) you want:
@@ -102,7 +111,7 @@ To use any model from OpenRouter, just change the `model` parameter to the [mode
     openai_base_url: https://api.openai.com/v1
 ```
 
-### DeepSeek
+### DeepSeek (via openai provider)
 
 ```yaml
 - uses: Stone-IT-Cloud/gemini-code-review-action@v1

--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ author: "rubensflinco"
 
 inputs:
   llm_provider:
-    description: "LLM provider to use (gemini, openai, anthropic). Defaults to LLM_PROVIDER env var or 'gemini'."
+    description: "LLM provider to use (gemini, openai, openrouter, anthropic). Defaults to LLM_PROVIDER env var or 'gemini'."
     required: false
     default: "gemini"
   gemini_api_key:

--- a/src/config.py
+++ b/src/config.py
@@ -37,6 +37,7 @@ class AiReviewConfig(TypedDict):
 _PROVIDER_API_KEYS: dict[str, str] = {
     "gemini": "GEMINI_API_KEY",
     "openai": "OPENAI_API_KEY",
+    "openrouter": "OPENAI_API_KEY",
     "anthropic": "ANTHROPIC_API_KEY",
 }
 

--- a/src/llm/openai_client.py
+++ b/src/llm/openai_client.py
@@ -9,15 +9,15 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-"""OpenAI-compatible provider — supports OpenRouter, OpenAI, DeepSeek, Kimi, Qwen.
+"""OpenAI-compatible provider — supports OpenAI, OpenRouter, DeepSeek, Kimi, Qwen.
 
 Uses the OpenAI-compatible ``/chat/completions`` REST API via ``requests``.
 Configure via environment variables:
   - ``OPENAI_API_KEY`` or ``LLM_API_KEY`` (required)
-  - ``OPENAI_BASE_URL`` (optional, defaults to ``https://openrouter.ai/api/v1``)
+  - ``OPENAI_BASE_URL`` (optional, defaults to ``https://api.openai.com/v1``)
 
-To use OpenRouter, leave ``OPENAI_BASE_URL`` unset (defaults to OpenRouter).
-To use OpenAI directly, set ``OPENAI_BASE_URL=https://api.openai.com/v1``.
+Registered as ``"openai"`` (defaults to OpenAI) and ``"openrouter"`` (defaults to
+OpenRouter). Both use the same ``OpenAIClient`` class under the hood.
 """
 
 from __future__ import annotations
@@ -32,7 +32,8 @@ from src.llm.base import LLMClient, LLMConfig, LLMResponse
 from src.llm.provider_registry import register_provider
 
 DEFAULT_TOKEN_LIMIT = 128_000
-DEFAULT_BASE_URL = "https://openrouter.ai/api/v1"
+OPENAI_BASE_URL = "https://api.openai.com/v1"
+OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 
 # Known context limits for common models (tokens)
 _KNOWN_CONTEXT_LIMITS: dict[str, int] = {
@@ -78,7 +79,7 @@ class OpenAIClient(LLMClient):
         """Create an OpenAIClient from environment variables.
 
         Reads ``OPENAI_API_KEY`` (or ``LLM_API_KEY`` as fallback)
-        and ``OPENAI_BASE_URL`` (defaults to OpenRouter).
+        and ``OPENAI_BASE_URL`` (defaults to OpenAI API).
         """
         api_key = os.getenv("OPENAI_API_KEY") or os.getenv("LLM_API_KEY")
         if not api_key:
@@ -86,7 +87,7 @@ class OpenAIClient(LLMClient):
                 "OPENAI_API_KEY or LLM_API_KEY is required for the 'openai' provider. "
                 "Set it as an environment variable."
             )
-        base_url = os.getenv("OPENAI_BASE_URL", DEFAULT_BASE_URL)
+        base_url = os.getenv("OPENAI_BASE_URL", OPENAI_BASE_URL)
         return cls(api_key=api_key, base_url=base_url)
 
     def generate_content(self, prompt: str, config: LLMConfig) -> LLMResponse:
@@ -151,4 +152,28 @@ class OpenAIClient(LLMClient):
         return payload
 
 
+class OpenRouterClient(OpenAIClient):
+    """OpenAIClient subclass that defaults to OpenRouter's base URL.
+
+    Registered as ``"openrouter"`` provider.
+    """
+
+    @classmethod
+    def from_env(cls) -> OpenRouterClient:
+        """Create an OpenRouter client from environment variables.
+
+        Reads ``OPENAI_API_KEY`` (or ``LLM_API_KEY``) and ``OPENAI_BASE_URL``
+        (defaults to ``https://openrouter.ai/api/v1``).
+        """
+        api_key = os.getenv("OPENAI_API_KEY") or os.getenv("LLM_API_KEY")
+        if not api_key:
+            raise ValueError(
+                "OPENAI_API_KEY or LLM_API_KEY is required for the 'openrouter' provider. "
+                "Set it as an environment variable."
+            )
+        base_url = os.getenv("OPENAI_BASE_URL", OPENROUTER_BASE_URL)
+        return cls(api_key=api_key, base_url=base_url)
+
+
 register_provider("openai", OpenAIClient)
+register_provider("openrouter", OpenRouterClient)

--- a/src/main.py
+++ b/src/main.py
@@ -424,7 +424,7 @@ def _dispatch_ci_output(
 )
 @click.option(
     "--provider",
-    type=click.Choice(["gemini", "openai", "anthropic"], case_sensitive=False),
+    type=click.Choice(["gemini", "openai", "openrouter", "anthropic"], case_sensitive=False),
     required=False,
     default=None,
     help="LLM provider (gemini, openai, anthropic). Defaults to LLM_PROVIDER env var or 'gemini'.",

--- a/test/test_openai_client.py
+++ b/test/test_openai_client.py
@@ -116,11 +116,11 @@ class TestOpenAIClientFactory:
     """Tests for OpenAIClient.from_env()."""
 
     def test_from_env_with_api_key(self):
-        """OPENAI_API_KEY crea cliente correctamente."""
+        """OPENAI_API_KEY crea cliente con default OpenAI."""
         with patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test123"}):
             client = OpenAIClient.from_env()
             assert client._api_key == "sk-test123"
-            assert client._base_url == "https://openrouter.ai/api/v1"
+            assert client._base_url == "https://api.openai.com/v1"
 
     def test_from_env_with_llm_api_key_fallback(self):
         """LLM_API_KEY funciona como fallback si OPENAI_API_KEY no está."""
@@ -139,3 +139,33 @@ class TestOpenAIClientFactory:
         with patch.dict("os.environ", {}, clear=True):
             with pytest.raises(ValueError, match="OPENAI_API_KEY"):
                 OpenAIClient.from_env()
+
+
+class TestOpenRouterClient:
+    """Tests for OpenRouterClient (openrouter provider alias)."""
+
+    def test_openrouter_is_registered(self):
+        """openrouter provider debe estar registrado."""
+        from src.llm import list_providers
+        assert "openrouter" in list_providers()
+
+    def test_openrouter_defaults_to_openrouter_url(self):
+        """OpenRouterClient usa https://openrouter.ai/api/v1 por defecto."""
+        from src.llm.openai_client import OpenRouterClient
+        with patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}):
+            client = OpenRouterClient.from_env()
+            assert client._base_url == "https://openrouter.ai/api/v1"
+
+    def test_openrouter_respects_custom_base_url(self):
+        """OpenRouterClient respeta OPENAI_BASE_URL si se setea."""
+        from src.llm.openai_client import OpenRouterClient
+        with patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test", "OPENAI_BASE_URL": "https://custom.api/v1"}):
+            client = OpenRouterClient.from_env()
+            assert client._base_url == "https://custom.api/v1"
+
+    def test_openrouter_missing_key_raises(self):
+        """Sin API key lanza ValueError."""
+        from src.llm.openai_client import OpenRouterClient
+        with patch.dict("os.environ", {}, clear=True):
+            with pytest.raises(ValueError, match="OPENAI_API_KEY"):
+                OpenRouterClient.from_env()


### PR DESCRIPTION
## Cambios

### usage: openai [-h] [-v] [-b API_BASE] [-k API_KEY] [-p PROXY [PROXY ...]]
              [-o ORGANIZATION] [-t {openai,azure}]
              [--api-version API_VERSION] [--azure-endpoint AZURE_ENDPOINT]
              [--azure-ad-token AZURE_AD_TOKEN] [-V]
              {api,tools,migrate,grit} ...

positional arguments:
  {api,tools,migrate,grit}
    api                 Direct API calls
    tools               Client side tools for convenience

options:
  -h, --help            show this help message and exit
  -v, --verbose         Set verbosity.
  -b API_BASE, --api-base API_BASE
                        What API base url to use.
  -k API_KEY, --api-key API_KEY
                        What API key to use.
  -p PROXY [PROXY ...], --proxy PROXY [PROXY ...]
                        What proxy to use.
  -o ORGANIZATION, --organization ORGANIZATION
                        Which organization to run as (will use your default
                        organization if not specified)
  -t {openai,azure}, --api-type {openai,azure}
                        The backend API to call, must be `openai` or `azure`
  --api-version API_VERSION
                        The Azure API version, e.g.
                        'https://learn.microsoft.com/en-us/azure/ai-
                        services/openai/reference#rest-api-versioning'
  --azure-endpoint AZURE_ENDPOINT
                        The Azure endpoint, e.g.
                        'https://endpoint.openai.azure.com'
  --azure-ad-token AZURE_AD_TOKEN
                        A token from Azure Active Directory,
                        https://www.microsoft.com/en-
                        us/security/business/identity-access/microsoft-entra-
                        id
  -V, --version         show program's version number and exit provider ahora apunta a OpenAI por defecto

Antes, `llm_provider: openai` usaba OpenRouter por defecto. Había que setear `OPENAI_BASE_URL` para usar OpenAI. Ahora:

```yaml
- uses: Stone-IT-Cloud/gemini-code-review-action@v1
  with:
    llm_provider: openai
    openai_api_key: $\{{ secrets.OPENAI_API_KEY \}}
    model: gpt-4o            # Funciona directo, sin BASE_URL
```

### Nuevo `openrouter` provider alias

Para OpenRouter ahora hay un provider dedicado:

```yaml
- uses: Stone-IT-Cloud/gemini-code-review-action@v1
  with:
    llm_provider: openrouter
    openai_api_key: $\{{ secrets.OPENROUTER_API_KEY \}}
    model: anthropic/claude-sonnet-4   # Slugs de OpenRouter
``"

### Arquitectura

`OpenRouterClient(OpenAIClient)` — subclass que solo overrides `from_env()` para cambiar el default URL. SOLID, Liskov-compliant, sin monkey-patching.

### Docs

README actualizado: OpenAI como provider separado, OpenRouter con `llm_provider: openrouter`, DeepSeek como ejemplo de API compatible.

### Tests

✅ **20 tests** — incluye 4 nuevos para OpenRouterClient
