### PR TITLE
feat: Chinese LLM providers (DeepSeek, Qwen, Kimi, Baichuan, ZhipuAI)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,11 @@ Then add `from src.llm import myclient` to `src/llm/__init__.py`.
 | gemini | `GEMINI_API_KEY` | — | — |
 | openai | `OPENAI_API_KEY` or `LLM_API_KEY` | `OPENAI_BASE_URL` | `https://api.openai.com/v1` |
 | openrouter | `OPENAI_API_KEY` or `LLM_API_KEY` | `OPENAI_BASE_URL` | `https://openrouter.ai/api/v1` |
+| deepseek | `DEEPSEEK_API_KEY` | `DEEPSEEK_BASE_URL` | `https://api.deepseek.com/v1` |
+| qwen | `QWEN_API_KEY` or `DASHSCOPE_API_KEY` | `QWEN_BASE_URL` | `https://dashscope.aliyuncs.com/compatible-mode/v1` |
+| kimi | `KIMI_API_KEY` or `MOONSHOT_API_KEY` | `KIMI_BASE_URL` | `https://api.moonshot.cn/v1` |
+| baichuan | `BAICHUAN_API_KEY` | `BAICHUAN_BASE_URL` | `https://api.baichuan-ai.com/v1` |
+| zhipu | `ZHIPU_API_KEY` | `ZHIPU_BASE_URL` | `https://open.bigmodel.cn/api/paas/v4` |
 | (yours) | `YOUR_API_KEY` | `YOUR_BASE_URL` | — |
 
 ### Testing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,8 @@ Then add `from src.llm import myclient` to `src/llm/__init__.py`.
 | Provider | API key env | Base URL env | Default URL |
 |----------|------------|-------------|-------------|
 | gemini | `GEMINI_API_KEY` | — | — |
-| openai | `OPENAI_API_KEY` or `LLM_API_KEY` | `OPENAI_BASE_URL` | `https://openrouter.ai/api/v1` |
+| openai | `OPENAI_API_KEY` or `LLM_API_KEY` | `OPENAI_BASE_URL` | `https://api.openai.com/v1` |
+| openrouter | `OPENAI_API_KEY` or `LLM_API_KEY` | `OPENAI_BASE_URL` | `https://openrouter.ai/api/v1` |
 | (yours) | `YOUR_API_KEY` | `YOUR_BASE_URL` | — |
 
 ### Testing

--- a/README.md
+++ b/README.md
@@ -111,7 +111,17 @@ To use any model from OpenRouter, just change the `model` parameter to the [mode
     openai_base_url: https://api.openai.com/v1
 ```
 
-### DeepSeek (via openai provider)
+### DeepSeek (via dedicated deepseek provider)
+
+```yaml
+- uses: Stone-IT-Cloud/gemini-code-review-action@v1
+  with:
+    llm_provider: deepseek
+    deepseek_api_key: ${{ secrets.DEEPSEEK_API_KEY }}
+    model: deepseek-chat
+```
+
+Or via the generic `openai` provider (any OpenAI-compatible API):
 
 ```yaml
 - uses: Stone-IT-Cloud/gemini-code-review-action@v1
@@ -120,6 +130,46 @@ To use any model from OpenRouter, just change the `model` parameter to the [mode
     openai_api_key: ${{ secrets.DEEPSEEK_API_KEY }}
     model: deepseek-chat
     openai_base_url: https://api.deepseek.com/v1
+```
+
+### Qwen (Alibaba Cloud)
+
+```yaml
+- uses: Stone-IT-Cloud/gemini-code-review-action@v1
+  with:
+    llm_provider: qwen
+    qwen_api_key: ${{ secrets.QWEN_API_KEY }}
+    model: qwen-plus
+```
+
+### Kimi (Moonshot AI)
+
+```yaml
+- uses: Stone-IT-Cloud/gemini-code-review-action@v1
+  with:
+    llm_provider: kimi
+    kimi_api_key: ${{ secrets.KIMI_API_KEY }}
+    model: moonshot-v1-128k
+```
+
+### Baichuan AI
+
+```yaml
+- uses: Stone-IT-Cloud/gemini-code-review-action@v1
+  with:
+    llm_provider: baichuan
+    baichuan_api_key: ${{ secrets.BAICHUAN_API_KEY }}
+    model: Baichuan4
+```
+
+### Zhipu AI (GLM)
+
+```yaml
+- uses: Stone-IT-Cloud/gemini-code-review-action@v1
+  with:
+    llm_provider: zhipu
+    zhipu_api_key: ${{ secrets.ZHIPU_API_KEY }}
+    model: glm-4-plus
 ```
 
 ## Features
@@ -446,6 +496,7 @@ src/
     ├── provider_registry.py  # Provider registration and factory
     ├── gemini_client.py # Gemini provider
     ├── openai_client.py # OpenAI-compatible provider (OpenRouter, DeepSeek, etc.)
+    ├── chinese_providers.py  # DeepSeek, Qwen, Kimi, Baichuan, ZhipuAI
     └── review.py        # Provider-agnostic review workflow (chunking, summarization)
 ```
 ## Architecture: LLM Provider Abstraction

--- a/README.md
+++ b/README.md
@@ -66,17 +66,26 @@ The action supports multiple LLM providers. Set the `llm_provider` input (or `LL
     model: gemini-2.5-flash
 ```
 
-### OpenRouter (any model from 300+ providers)
-
-[OpenRouter](https://openrouter.ai) gives you access to 300+ models (OpenAI, Anthropic, Google, Meta, Mistral, DeepSeek, Qwen, etc.) through a single API.
+### OpenAI (default for openai provider)
 
 ```yaml
 - uses: Stone-IT-Cloud/gemini-code-review-action@v1
   with:
     llm_provider: openai
+    openai_api_key: ${{ secrets.OPENAI_API_KEY }}
+    model: gpt-4o
+```
+
+### OpenRouter (any model from 300+ providers)
+
+[OpenRouter](https://openrouter.ai) gives you access to 300+ models (OpenAI, Anthropic, Google, Meta, Mistral, DeepSeek, Qwen, etc.) through a single API. Use `llm_provider: openrouter` (no need to set `openai_base_url`).
+
+```yaml
+- uses: Stone-IT-Cloud/gemini-code-review-action@v1
+  with:
+    llm_provider: openrouter
     openai_api_key: ${{ secrets.OPENROUTER_API_KEY }}
     model: openai/gpt-4o          # Any OpenRouter model slug
-    openai_base_url: https://openrouter.ai/api/v1  # Default, can omit
 ```
 
 To use any model from OpenRouter, just change the `model` parameter to the [model slug](https://openrouter.ai/models) you want:
@@ -102,7 +111,7 @@ To use any model from OpenRouter, just change the `model` parameter to the [mode
     openai_base_url: https://api.openai.com/v1
 ```
 
-### DeepSeek
+### DeepSeek (via openai provider)
 
 ```yaml
 - uses: Stone-IT-Cloud/gemini-code-review-action@v1

--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ author: "rubensflinco"
 
 inputs:
   llm_provider:
-    description: "LLM provider to use (gemini, openai, openrouter, anthropic). Defaults to LLM_PROVIDER env var or 'gemini'."
+    description: "LLM provider (gemini, openai, openrouter, deepseek, qwen, kimi, baichuan, zhipu, anthropic). Defaults to 'gemini'."
     required: false
     default: "gemini"
   gemini_api_key:

--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ author: "rubensflinco"
 
 inputs:
   llm_provider:
-    description: "LLM provider to use (gemini, openai, anthropic). Defaults to LLM_PROVIDER env var or 'gemini'."
+    description: "LLM provider to use (gemini, openai, openrouter, anthropic). Defaults to LLM_PROVIDER env var or 'gemini'."
     required: false
     default: "gemini"
   gemini_api_key:

--- a/src/config.py
+++ b/src/config.py
@@ -38,6 +38,11 @@ _PROVIDER_API_KEYS: dict[str, str] = {
     "gemini": "GEMINI_API_KEY",
     "openai": "OPENAI_API_KEY",
     "openrouter": "OPENAI_API_KEY",
+    "deepseek": "DEEPSEEK_API_KEY",
+    "qwen": "QWEN_API_KEY",
+    "kimi": "KIMI_API_KEY",
+    "baichuan": "BAICHUAN_API_KEY",
+    "zhipu": "ZHIPU_API_KEY",
     "anthropic": "ANTHROPIC_API_KEY",
 }
 

--- a/src/config.py
+++ b/src/config.py
@@ -37,6 +37,7 @@ class AiReviewConfig(TypedDict):
 _PROVIDER_API_KEYS: dict[str, str] = {
     "gemini": "GEMINI_API_KEY",
     "openai": "OPENAI_API_KEY",
+    "openrouter": "OPENAI_API_KEY",
     "anthropic": "ANTHROPIC_API_KEY",
 }
 

--- a/src/llm/__init__.py
+++ b/src/llm/__init__.py
@@ -18,6 +18,7 @@ from src.llm.provider_registry import get_llm_client, list_providers, register_p
 # Each provider module calls register_provider() at import time.
 from src.llm import gemini_client  # noqa: F401
 from src.llm import openai_client  # noqa: F401
+from src.llm import chinese_providers  # noqa: F401
 
 __all__ = [
     "LLMClient",

--- a/src/llm/chinese_providers.py
+++ b/src/llm/chinese_providers.py
@@ -1,0 +1,147 @@
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#          http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Chinese LLM providers — DeepSeek, Qwen, Kimi, Baichuan, ZhipuAI (GLM).
+
+All use OpenAI-compatible ``/chat/completions`` REST API.
+Each provider is a lightweight ``OpenAIClient`` subclass that only overrides
+``from_env()`` to set its default API key env var and base URL.
+"""
+
+from __future__ import annotations
+
+import os
+
+from src.llm.openai_client import OpenAIClient
+from src.llm.provider_registry import register_provider
+
+# ── Base URLs ───────────────────────────────────────────────────────────────
+
+DEEPSEEK_BASE_URL = "https://api.deepseek.com/v1"
+QWEN_BASE_URL = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+KIMI_BASE_URL = "https://api.moonshot.cn/v1"
+BAICHUAN_BASE_URL = "https://api.baichuan-ai.com/v1"
+ZHIPU_BASE_URL = "https://open.bigmodel.cn/api/paas/v4"
+
+
+# ── Provider subclasses ─────────────────────────────────────────────────────
+
+
+class DeepSeekClient(OpenAIClient):
+    """DeepSeek provider (https://platform.deepseek.com).
+
+    Registered as ``"deepseek"``.
+    Reads ``DEEPSEEK_API_KEY`` (or ``OPENAI_API_KEY`` as fallback).
+    """
+
+    @classmethod
+    def from_env(cls) -> DeepSeekClient:
+        api_key = os.getenv("DEEPSEEK_API_KEY") or os.getenv("OPENAI_API_KEY")
+        if not api_key:
+            raise ValueError(
+                "DEEPSEEK_API_KEY or OPENAI_API_KEY is required "
+                "for the 'deepseek' provider."
+            )
+        base_url = os.getenv("DEEPSEEK_BASE_URL", DEEPSEEK_BASE_URL)
+        return cls(api_key=api_key, base_url=base_url)
+
+
+class QwenClient(OpenAIClient):
+    """Qwen (Alibaba Cloud) provider (https://help.aliyun.com/model-studio).
+
+    Registered as ``"qwen"``.
+    Reads ``QWEN_API_KEY`` (or ``DASHSCOPE_API_KEY`` or ``OPENAI_API_KEY``).
+    """
+
+    @classmethod
+    def from_env(cls) -> QwenClient:
+        api_key = (
+            os.getenv("QWEN_API_KEY")
+            or os.getenv("DASHSCOPE_API_KEY")
+            or os.getenv("OPENAI_API_KEY")
+        )
+        if not api_key:
+            raise ValueError(
+                "QWEN_API_KEY, DASHSCOPE_API_KEY, or OPENAI_API_KEY is required "
+                "for the 'qwen' provider."
+            )
+        base_url = os.getenv("QWEN_BASE_URL", QWEN_BASE_URL)
+        return cls(api_key=api_key, base_url=base_url)
+
+
+class KimiClient(OpenAIClient):
+    """Kimi (Moonshot AI) provider (https://platform.moonshot.cn).
+
+    Registered as ``"kimi"``.
+    Reads ``KIMI_API_KEY`` (or ``MOONSHOT_API_KEY`` or ``OPENAI_API_KEY``).
+    """
+
+    @classmethod
+    def from_env(cls) -> KimiClient:
+        api_key = (
+            os.getenv("KIMI_API_KEY")
+            or os.getenv("MOONSHOT_API_KEY")
+            or os.getenv("OPENAI_API_KEY")
+        )
+        if not api_key:
+            raise ValueError(
+                "KIMI_API_KEY, MOONSHOT_API_KEY, or OPENAI_API_KEY is required "
+                "for the 'kimi' provider."
+            )
+        base_url = os.getenv("KIMI_BASE_URL", KIMI_BASE_URL)
+        return cls(api_key=api_key, base_url=base_url)
+
+
+class BaichuanClient(OpenAIClient):
+    """Baichuan AI provider (https://platform.baichuan-ai.com).
+
+    Registered as ``"baichuan"``.
+    Reads ``BAICHUAN_API_KEY`` (or ``OPENAI_API_KEY``).
+    """
+
+    @classmethod
+    def from_env(cls) -> BaichuanClient:
+        api_key = os.getenv("BAICHUAN_API_KEY") or os.getenv("OPENAI_API_KEY")
+        if not api_key:
+            raise ValueError(
+                "BAICHUAN_API_KEY or OPENAI_API_KEY is required "
+                "for the 'baichuan' provider."
+            )
+        base_url = os.getenv("BAICHUAN_BASE_URL", BAICHUAN_BASE_URL)
+        return cls(api_key=api_key, base_url=base_url)
+
+
+class ZhipuClient(OpenAIClient):
+    """Zhipu AI (GLM) provider (https://open.bigmodel.cn).
+
+    Registered as ``"zhipu"``.
+    Reads ``ZHIPU_API_KEY`` (or ``OPENAI_API_KEY``).
+    """
+
+    @classmethod
+    def from_env(cls) -> ZhipuClient:
+        api_key = os.getenv("ZHIPU_API_KEY") or os.getenv("OPENAI_API_KEY")
+        if not api_key:
+            raise ValueError(
+                "ZHIPU_API_KEY or OPENAI_API_KEY is required "
+                "for the 'zhipu' provider."
+            )
+        base_url = os.getenv("ZHIPU_BASE_URL", ZHIPU_BASE_URL)
+        return cls(api_key=api_key, base_url=base_url)
+
+
+# ── Register ────────────────────────────────────────────────────────────────
+
+register_provider("deepseek", DeepSeekClient)
+register_provider("qwen", QwenClient)
+register_provider("kimi", KimiClient)
+register_provider("baichuan", BaichuanClient)
+register_provider("zhipu", ZhipuClient)

--- a/src/llm/openai_client.py
+++ b/src/llm/openai_client.py
@@ -9,15 +9,15 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-"""OpenAI-compatible provider — supports OpenRouter, OpenAI, DeepSeek, Kimi, Qwen.
+"""OpenAI-compatible provider — supports OpenAI, OpenRouter, DeepSeek, Kimi, Qwen.
 
 Uses the OpenAI-compatible ``/chat/completions`` REST API via ``requests``.
 Configure via environment variables:
   - ``OPENAI_API_KEY`` or ``LLM_API_KEY`` (required)
-  - ``OPENAI_BASE_URL`` (optional, defaults to ``https://openrouter.ai/api/v1``)
+  - ``OPENAI_BASE_URL`` (optional, defaults to ``https://api.openai.com/v1``)
 
-To use OpenRouter, leave ``OPENAI_BASE_URL`` unset (defaults to OpenRouter).
-To use OpenAI directly, set ``OPENAI_BASE_URL=https://api.openai.com/v1``.
+Registered as ``"openai"`` (defaults to OpenAI) and ``"openrouter"`` (defaults to
+OpenRouter). Both use the same ``OpenAIClient`` class under the hood.
 """
 
 from __future__ import annotations
@@ -32,7 +32,8 @@ from src.llm.base import LLMClient, LLMConfig, LLMResponse
 from src.llm.provider_registry import register_provider
 
 DEFAULT_TOKEN_LIMIT = 128_000
-DEFAULT_BASE_URL = "https://openrouter.ai/api/v1"
+OPENAI_BASE_URL = "https://api.openai.com/v1"
+OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 
 # Known context limits for common models (tokens)
 _KNOWN_CONTEXT_LIMITS: dict[str, int] = {
@@ -78,7 +79,7 @@ class OpenAIClient(LLMClient):
         """Create an OpenAIClient from environment variables.
 
         Reads ``OPENAI_API_KEY`` (or ``LLM_API_KEY`` as fallback)
-        and ``OPENAI_BASE_URL`` (defaults to OpenRouter).
+        and ``OPENAI_BASE_URL`` (defaults to OpenAI API).
         """
         api_key = os.getenv("OPENAI_API_KEY") or os.getenv("LLM_API_KEY")
         if not api_key:
@@ -86,7 +87,7 @@ class OpenAIClient(LLMClient):
                 "OPENAI_API_KEY or LLM_API_KEY is required for the 'openai' provider. "
                 "Set it as an environment variable."
             )
-        base_url = os.getenv("OPENAI_BASE_URL", DEFAULT_BASE_URL)
+        base_url = os.getenv("OPENAI_BASE_URL", OPENAI_BASE_URL)
         return cls(api_key=api_key, base_url=base_url)
 
     def generate_content(self, prompt: str, config: LLMConfig) -> LLMResponse:
@@ -151,4 +152,28 @@ class OpenAIClient(LLMClient):
         return payload
 
 
+class OpenRouterClient(OpenAIClient):
+    """OpenAIClient subclass that defaults to OpenRouter's base URL.
+
+    Registered as ``"openrouter"`` provider.
+    """
+
+    @classmethod
+    def from_env(cls) -> OpenRouterClient:
+        """Create an OpenRouter client from environment variables.
+
+        Reads ``OPENAI_API_KEY`` (or ``LLM_API_KEY``) and ``OPENAI_BASE_URL``
+        (defaults to ``https://openrouter.ai/api/v1``).
+        """
+        api_key = os.getenv("OPENAI_API_KEY") or os.getenv("LLM_API_KEY")
+        if not api_key:
+            raise ValueError(
+                "OPENAI_API_KEY or LLM_API_KEY is required for the 'openrouter' provider. "
+                "Set it as an environment variable."
+            )
+        base_url = os.getenv("OPENAI_BASE_URL", OPENROUTER_BASE_URL)
+        return cls(api_key=api_key, base_url=base_url)
+
+
 register_provider("openai", OpenAIClient)
+register_provider("openrouter", OpenRouterClient)

--- a/src/main.py
+++ b/src/main.py
@@ -424,7 +424,7 @@ def _dispatch_ci_output(
 )
 @click.option(
     "--provider",
-    type=click.Choice(["gemini", "openai", "anthropic"], case_sensitive=False),
+    type=click.Choice(["gemini", "openai", "openrouter", "anthropic"], case_sensitive=False),
     required=False,
     default=None,
     help="LLM provider (gemini, openai, anthropic). Defaults to LLM_PROVIDER env var or 'gemini'.",

--- a/src/main.py
+++ b/src/main.py
@@ -424,7 +424,11 @@ def _dispatch_ci_output(
 )
 @click.option(
     "--provider",
-    type=click.Choice(["gemini", "openai", "openrouter", "anthropic"], case_sensitive=False),
+    type=click.Choice(
+        ["gemini", "openai", "openrouter", "deepseek", "qwen", "kimi",
+         "baichuan", "zhipu", "anthropic"],
+        case_sensitive=False,
+    ),
     required=False,
     default=None,
     help="LLM provider (gemini, openai, anthropic). Defaults to LLM_PROVIDER env var or 'gemini'.",

--- a/test/test_chinese_providers.py
+++ b/test/test_chinese_providers.py
@@ -1,0 +1,120 @@
+"""Tests for src/llm/chinese_providers.py — DeepSeek, Qwen, Kimi, Baichuan, Zhipu."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from src.llm.chinese_providers import (
+    BaichuanClient,
+    DeepSeekClient,
+    KimiClient,
+    QwenClient,
+    ZhipuClient,
+)
+
+
+class TestChineseProvidersRegistration:
+    """All Chinese providers must be registered."""
+
+    def test_all_providers_registered(self):
+        from src.llm import list_providers
+        providers = list_providers()
+        for name in ("deepseek", "qwen", "kimi", "baichuan", "zhipu"):
+            assert name in providers, f"{name} not registered"
+
+
+class TestDeepSeekClient:
+    def test_default_url(self):
+        with patch.dict("os.environ", {"DEEPSEEK_API_KEY": "sk-test"}):
+            c = DeepSeekClient.from_env()
+            assert c._base_url == "https://api.deepseek.com/v1"
+
+    def test_fallsback_to_openai_api_key(self):
+        with patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}):
+            c = DeepSeekClient.from_env()
+            assert c._api_key == "sk-test"
+
+    def test_missing_key_raises(self):
+        with patch.dict("os.environ", {}, clear=True):
+            with pytest.raises(ValueError, match="DEEPSEEK_API_KEY"):
+                DeepSeekClient.from_env()
+
+
+class TestQwenClient:
+    def test_default_url(self):
+        with patch.dict("os.environ", {"QWEN_API_KEY": "sk-test"}):
+            c = QwenClient.from_env()
+            assert c._base_url == "https://dashscope.aliyuncs.com/compatible-mode/v1"
+
+    def test_fallsback_to_dashscope_key(self):
+        with patch.dict("os.environ", {"DASHSCOPE_API_KEY": "sk-dash"}):
+            c = QwenClient.from_env()
+            assert c._api_key == "sk-dash"
+
+    def test_fallsback_to_openai_key(self):
+        with patch.dict("os.environ", {"OPENAI_API_KEY": "sk-openai"}):
+            c = QwenClient.from_env()
+            assert c._api_key == "sk-openai"
+
+    def test_missing_key_raises(self):
+        with patch.dict("os.environ", {}, clear=True):
+            with pytest.raises(ValueError, match="QWEN_API_KEY"):
+                QwenClient.from_env()
+
+
+class TestKimiClient:
+    def test_default_url(self):
+        with patch.dict("os.environ", {"KIMI_API_KEY": "sk-test"}):
+            c = KimiClient.from_env()
+            assert c._base_url == "https://api.moonshot.cn/v1"
+
+    def test_fallsback_to_moonshot_key(self):
+        with patch.dict("os.environ", {"MOONSHOT_API_KEY": "sk-moon"}):
+            c = KimiClient.from_env()
+            assert c._api_key == "sk-moon"
+
+    def test_fallsback_to_openai_key(self):
+        with patch.dict("os.environ", {"OPENAI_API_KEY": "sk-openai"}):
+            c = KimiClient.from_env()
+            assert c._api_key == "sk-openai"
+
+    def test_missing_key_raises(self):
+        with patch.dict("os.environ", {}, clear=True):
+            with pytest.raises(ValueError, match="KIMI_API_KEY"):
+                KimiClient.from_env()
+
+
+class TestBaichuanClient:
+    def test_default_url(self):
+        with patch.dict("os.environ", {"BAICHUAN_API_KEY": "sk-test"}):
+            c = BaichuanClient.from_env()
+            assert c._base_url == "https://api.baichuan-ai.com/v1"
+
+    def test_fallsback_to_openai_key(self):
+        with patch.dict("os.environ", {"OPENAI_API_KEY": "sk-oa"}):
+            c = BaichuanClient.from_env()
+            assert c._api_key == "sk-oa"
+
+    def test_missing_key_raises(self):
+        with patch.dict("os.environ", {}, clear=True):
+            with pytest.raises(ValueError, match="BAICHUAN_API_KEY"):
+                BaichuanClient.from_env()
+
+
+class TestZhipuClient:
+    def test_default_url(self):
+        with patch.dict("os.environ", {"ZHIPU_API_KEY": "sk-test"}):
+            c = ZhipuClient.from_env()
+            assert c._base_url == "https://open.bigmodel.cn/api/paas/v4"
+
+    def test_fallsback_to_openai_key(self):
+        with patch.dict("os.environ", {"OPENAI_API_KEY": "sk-oa"}):
+            c = ZhipuClient.from_env()
+            assert c._api_key == "sk-oa"
+
+    def test_missing_key_raises(self):
+        with patch.dict("os.environ", {}, clear=True):
+            with pytest.raises(ValueError, match="ZHIPU_API_KEY"):
+                ZhipuClient.from_env()

--- a/test/test_openai_client.py
+++ b/test/test_openai_client.py
@@ -116,11 +116,11 @@ class TestOpenAIClientFactory:
     """Tests for OpenAIClient.from_env()."""
 
     def test_from_env_with_api_key(self):
-        """OPENAI_API_KEY crea cliente correctamente."""
+        """OPENAI_API_KEY crea cliente con default OpenAI."""
         with patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test123"}):
             client = OpenAIClient.from_env()
             assert client._api_key == "sk-test123"
-            assert client._base_url == "https://openrouter.ai/api/v1"
+            assert client._base_url == "https://api.openai.com/v1"
 
     def test_from_env_with_llm_api_key_fallback(self):
         """LLM_API_KEY funciona como fallback si OPENAI_API_KEY no está."""
@@ -139,3 +139,33 @@ class TestOpenAIClientFactory:
         with patch.dict("os.environ", {}, clear=True):
             with pytest.raises(ValueError, match="OPENAI_API_KEY"):
                 OpenAIClient.from_env()
+
+
+class TestOpenRouterClient:
+    """Tests for OpenRouterClient (openrouter provider alias)."""
+
+    def test_openrouter_is_registered(self):
+        """openrouter provider debe estar registrado."""
+        from src.llm import list_providers
+        assert "openrouter" in list_providers()
+
+    def test_openrouter_defaults_to_openrouter_url(self):
+        """OpenRouterClient usa https://openrouter.ai/api/v1 por defecto."""
+        from src.llm.openai_client import OpenRouterClient
+        with patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}):
+            client = OpenRouterClient.from_env()
+            assert client._base_url == "https://openrouter.ai/api/v1"
+
+    def test_openrouter_respects_custom_base_url(self):
+        """OpenRouterClient respeta OPENAI_BASE_URL si se setea."""
+        from src.llm.openai_client import OpenRouterClient
+        with patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test", "OPENAI_BASE_URL": "https://custom.api/v1"}):
+            client = OpenRouterClient.from_env()
+            assert client._base_url == "https://custom.api/v1"
+
+    def test_openrouter_missing_key_raises(self):
+        """Sin API key lanza ValueError."""
+        from src.llm.openai_client import OpenRouterClient
+        with patch.dict("os.environ", {}, clear=True):
+            with pytest.raises(ValueError, match="OPENAI_API_KEY"):
+                OpenRouterClient.from_env()


### PR DESCRIPTION
## Nuevos providers

5 nuevos providers para modelos chinos, siguiendo el mismo patrón que :

| Provider | API Key | Default URL | Modelo ejemplo |
|---|---|---|---|
|  |  |  |  |
|  |  |  |  |
|  |  |  |  |
|  |  |  |  |
|  |  |  |  |

### Arquitectura

Todos son subclases de  que solo overrides . Cero duplicación de lógica — heredan , , .

Cada uno acepta su propia API key y también  como fallback.

### Archivos

-  — los 5 providers
-  — import del módulo
-  — API key env vars
-  —  choices
-  —  description
-  — 18 tests

### Tests

✅ **18 tests** — registration, default URLs, fallback keys, missing key errors
✅ **0 regresiones** — 38 tests total
