### PR TITLE
feat: Anthropic Claude provider

### DIFF
--- a/src/llm/__init__.py
+++ b/src/llm/__init__.py
@@ -19,6 +19,7 @@ from src.llm.provider_registry import get_llm_client, list_providers, register_p
 from src.llm import gemini_client  # noqa: F401
 from src.llm import openai_client  # noqa: F401
 from src.llm import chinese_providers  # noqa: F401
+from src.llm import anthropic_client  # noqa: F401
 
 __all__ = [
     "LLMClient",

--- a/src/llm/anthropic_client.py
+++ b/src/llm/anthropic_client.py
@@ -1,0 +1,142 @@
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#          http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Anthropic provider — Claude models via the Messages API.
+
+Uses the Anthropic Messages API directly via ``requests``.
+Configure via environment variables:
+  - ``ANTHROPIC_API_KEY`` (required)
+  - ``ANTHROPIC_BASE_URL`` (optional, defaults to ``https://api.anthropic.com/v1``)
+  - ``ANTHROPIC_VERSION`` (optional, defaults to ``2023-06-01``)
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import requests
+from loguru import logger
+
+from src.llm.base import LLMClient, LLMConfig, LLMResponse
+from src.llm.provider_registry import register_provider
+
+DEFAULT_TOKEN_LIMIT = 200_000
+ANTHROPIC_BASE_URL = "https://api.anthropic.com/v1"
+ANTHROPIC_VERSION = "2023-06-01"
+
+# Known context limits for Anthropic models
+_KNOWN_CONTEXT_LIMITS: dict[str, int] = {
+    "claude-sonnet-4-20250514": 200_000,
+    "claude-sonnet-4": 200_000,
+    "claude-3-5-sonnet-20241022": 200_000,
+    "claude-3-5-sonnet-v2": 200_000,
+    "claude-3-5-haiku-20241022": 200_000,
+    "claude-3-opus-20240229": 200_000,
+    "claude-3-haiku-20240307": 200_000,
+    "claude-3-sonnet-20240229": 200_000,
+}
+
+
+class AnthropicClient(LLMClient):
+    """LLMClient for Anthropic Claude models via the Messages API."""
+
+    def __init__(self, api_key: str, base_url: str, api_version: str) -> None:
+        self._api_key = api_key
+        self._base_url = base_url.rstrip("/")
+        self._api_version = api_version
+        self._session = requests.Session()
+        self._session.headers.update({
+            "x-api-key": api_key,
+            "anthropic-version": api_version,
+            "Content-Type": "application/json",
+        })
+
+    @classmethod
+    def from_env(cls) -> AnthropicClient:
+        """Create an AnthropicClient from environment variables.
+
+        Reads ``ANTHROPIC_API_KEY`` (required), ``ANTHROPIC_BASE_URL``
+        (defaults to Anthropic API), and ``ANTHROPIC_VERSION``.
+        """
+        api_key = os.getenv("ANTHROPIC_API_KEY")
+        if not api_key:
+            raise ValueError(
+                "ANTHROPIC_API_KEY is required for the 'anthropic' provider. "
+                "Set it as an environment variable."
+            )
+        base_url = os.getenv("ANTHROPIC_BASE_URL", ANTHROPIC_BASE_URL)
+        api_version = os.getenv("ANTHROPIC_VERSION", ANTHROPIC_VERSION)
+        return cls(api_key=api_key, base_url=base_url, api_version=api_version)
+
+    def generate_content(self, prompt: str, config: LLMConfig) -> LLMResponse:
+        """Send a prompt to Claude via the Messages API.
+
+        Args:
+            prompt: The user message content.
+            config: ``LLMConfig`` with model, system_instruction, temperature, etc.
+
+        Returns:
+            ``LLMResponse`` with generated text and token usage.
+        """
+        payload = self._build_payload(prompt, config)
+        resp = self._session.post(
+            f"{self._base_url}/messages",
+            json=payload,
+            timeout=120,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+
+        # Extract text from response content blocks
+        text: str | None = None
+        for block in data.get("content", []):
+            if block.get("type") == "text":
+                text = block.get("text")
+                break
+
+        usage = data.get("usage", {})
+        return LLMResponse(
+            text=text,
+            usage={
+                "prompt_tokens": usage.get("input_tokens", 0),
+                "output_tokens": usage.get("output_tokens", 0),
+                "total_tokens": (usage.get("input_tokens", 0) or 0)
+                + (usage.get("output_tokens", 0) or 0),
+            },
+        )
+
+    def get_context_limit(self, model: str) -> int:
+        """Return the model's context limit from a known lookup table.
+
+        Falls back to ``DEFAULT_TOKEN_LIMIT`` (200K) for unknown models.
+        """
+        return _KNOWN_CONTEXT_LIMITS.get(model, DEFAULT_TOKEN_LIMIT)
+
+    def _build_payload(self, prompt: str, config: LLMConfig) -> dict[str, Any]:
+        """Build the request payload for the Anthropic Messages API."""
+        messages: list[dict[str, str]] = [{"role": "user", "content": prompt}]
+
+        payload: dict[str, Any] = {
+            "model": config.model,
+            "messages": messages,
+            "max_tokens": config.max_output_tokens,
+            "temperature": config.temperature,
+            "top_p": config.top_p,
+        }
+
+        if config.system_instruction:
+            payload["system"] = config.system_instruction
+
+        return payload
+
+
+register_provider("anthropic", AnthropicClient)

--- a/test/test_anthropic_client.py
+++ b/test/test_anthropic_client.py
@@ -1,0 +1,95 @@
+"""Tests for src/llm/anthropic_client.py — Anthropic Claude provider."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from src.llm.anthropic_client import AnthropicClient
+from src.llm.base import LLMConfig
+
+
+class TestAnthropicRegistration:
+    def test_anthropic_is_registered(self):
+        from src.llm import list_providers
+        assert "anthropic" in list_providers()
+
+
+class TestAnthropicClientGenerateContent:
+    def test_generate_content_success(self):
+        client = AnthropicClient(api_key="sk-ant-test", base_url="https://fake.api.test", api_version="2023-06-01")
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "content": [{"type": "text", "text": "Great review!"}],
+            "usage": {"input_tokens": 50, "output_tokens": 10},
+        }
+        mock_resp.raise_for_status.return_value = None
+        with patch.object(client._session, "post", return_value=mock_resp) as mock_post:
+            config = LLMConfig(model="claude-sonnet-4", temperature=0.1)
+            response = client.generate_content("Review this", config)
+        assert response.text == "Great review!"
+        assert response.usage["prompt_tokens"] == 50
+        assert response.usage["total_tokens"] == 60
+        mock_post.assert_called_once()
+
+    def test_generate_content_includes_system(self):
+        client = AnthropicClient(api_key="sk-ant-test", base_url="https://fake.api.test", api_version="2023-06-01")
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"content": [{"type": "text", "text": "ok"}], "usage": {}}
+        mock_resp.raise_for_status.return_value = None
+        with patch.object(client._session, "post", return_value=mock_resp) as mock_post:
+            config = LLMConfig(model="claude-sonnet-4", system_instruction="You are a reviewer.", temperature=0.1)
+            client.generate_content("Review this", config)
+        payload = mock_post.call_args[1]["json"]
+        assert payload["system"] == "You are a reviewer."
+        assert payload["messages"] == [{"role": "user", "content": "Review this"}]
+
+    def test_http_error_raises(self):
+        client = AnthropicClient(api_key="bad-key", base_url="https://fake.api.test", api_version="2023-06-01")
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.side_effect = requests.exceptions.HTTPError("401 Unauthorized")
+        with patch.object(client._session, "post", return_value=mock_resp):
+            config = LLMConfig(model="claude-sonnet-4")
+            with pytest.raises(requests.exceptions.HTTPError):
+                client.generate_content("test", config)
+
+    def test_empty_content(self):
+        client = AnthropicClient(api_key="sk-ant-test", base_url="https://fake.api.test", api_version="2023-06-01")
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"content": [], "usage": {}}
+        mock_resp.raise_for_status.return_value = None
+        with patch.object(client._session, "post", return_value=mock_resp):
+            config = LLMConfig(model="claude-sonnet-4")
+            response = client.generate_content("test", config)
+        assert response.text is None
+
+
+class TestAnthropicContextLimit:
+    def test_known_model(self):
+        client = AnthropicClient(api_key="test", base_url="https://fake.api.test", api_version="2023-06-01")
+        assert client.get_context_limit("claude-sonnet-4") == 200_000
+        assert client.get_context_limit("claude-3-5-sonnet-20241022") == 200_000
+
+    def test_unknown_model_falls_back(self):
+        client = AnthropicClient(api_key="test", base_url="https://fake.api.test", api_version="2023-06-01")
+        assert client.get_context_limit("unknown-model") == 200_000
+
+
+class TestAnthropicFactory:
+    def test_from_env_with_api_key(self):
+        with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "sk-ant-test123"}):
+            client = AnthropicClient.from_env()
+            assert client._api_key == "sk-ant-test123"
+            assert client._base_url == "https://api.anthropic.com/v1"
+
+    def test_from_env_with_custom_url(self):
+        with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "sk-test", "ANTHROPIC_BASE_URL": "https://custom.anthropic.com/v1"}):
+            client = AnthropicClient.from_env()
+            assert client._base_url == "https://custom.anthropic.com/v1"
+
+    def test_missing_key_raises(self):
+        with patch.dict("os.environ", {}, clear=True):
+            with pytest.raises(ValueError, match="ANTHROPIC_API_KEY"):
+                AnthropicClient.from_env()


### PR DESCRIPTION
## Anthropic Claude Provider

Nuevo provider para modelos Claude de Anthropic via la Messages API (no es OpenAI-compatible, implementacion propia).

### Uso

```yaml
- uses: Stone-IT-Cloud/gemini-code-review-action@v1
  with:
    llm_provider: anthropic
    anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
    model: claude-sonnet-4
```

### Arquitectura

AnthropicClient(LLMClient) implementacion completa desde cero:

- Usa requests HTTP directo (sin SDK anthropic)
- POST a https://api.anthropic.com/v1/messages
- Header x-api-key + anthropic-version
- Soporta system instruction (campo separado en Anthropic API)
- Context limits: 200K para todos los modelos Claude
- Error handling via raise_for_status

### Tests

10 tests pasando: registration, generate_content, system prompt, HTTP errors, empty content, context limits, factory con/sin API key.