### PR TITLE
fix(review): remove empty array escape hatch and fix chunk config regression

### DIFF
--- a/src/llm/gemini_client.py
+++ b/src/llm/gemini_client.py
@@ -15,8 +15,6 @@ from __future__ import annotations
 
 import os
 import time
-from collections import deque
-from dataclasses import dataclass, field
 from typing import Any
 
 from google.genai import errors as gemini_errors
@@ -276,6 +274,7 @@ class GeminiClient(LLMClient):
                 min_request_interval=min_request_interval,
                 fail_fast_on_no_quota=fail_fast_on_no_quota,
                 tracker=tracker,
+                llm_config=llm_config,
             )
             if chunk_result is not None:
                 chunked_reviews.append(chunk_result)
@@ -312,6 +311,7 @@ class GeminiClient(LLMClient):
         min_request_interval: float,
         fail_fast_on_no_quota: bool,
         tracker: QuotaTracker,
+        llm_config: LLMConfig | None = None,
     ) -> str | None:
         """Process a single diff chunk with retry logic. Returns the review text or None."""
         for attempt in range(max_attempts):
@@ -329,14 +329,21 @@ class GeminiClient(LLMClient):
                 # reads those from the generate_content system_instruction.
                 prompt_parts.append("\n\nNow provide your review according to the earlier instructions.")
 
+                chunk_config = gemini_types.GenerateContentConfig(
+                    response_mime_type="application/json",
+                    system_instruction=llm_config.system_instruction if llm_config else None,
+                )
                 response = self._client.models.generate_content(
                     model=model,
                     contents="\n".join(prompt_parts),
+                    config=chunk_config,
                 )
                 now = time.time()
                 tracker.note_request(now)
                 review_result = _extract_model_text(response)
-                tracker.log_after_response(response, label=f"Gemini call success (review chunk {idx}/{total})", prefix="GEMINI")
+                tracker.log_after_response(
+                    response, label=f"Gemini call success (review chunk {idx}/{total})", prefix="GEMINI"
+                )
                 if review_result:
                     return review_result
             except gemini_errors.APIError as e:
@@ -352,7 +359,9 @@ class GeminiClient(LLMClient):
                 if should_retry:
                     continue
             except Exception as e:  # pylint: disable=broad-exception-caught
-                logger.error(f"Chunk {idx}/{total} attempt {attempt + 1}/{max_attempts} unexpected error: {_safe_str(e)}")
+                logger.error(
+                    f"Chunk {idx}/{total} attempt {attempt + 1}/{max_attempts} unexpected error: {_safe_str(e)}"
+                )
                 if attempt + 1 < max_attempts:
                     wait_time = min(max_wait, initial_wait * (2**attempt))
                     _sleep_with_jitter(wait_time)

--- a/src/review_parser.py
+++ b/src/review_parser.py
@@ -74,7 +74,9 @@ REVIEW_SYSTEM_PROMPT = (
     "put natural language descriptions, explanations, or advice in suggestion. "
     "Never use unified diff format (no ---, +++, @@, or +/- line prefixes). "
     "If you cannot provide a concrete code fix, omit suggestion or set it to null.\n"
-    "If you have no comments, return an empty JSON array: []\n"
+    "If you find no issues worthy of a review comment, produce a single item "
+    "with severity 'trivial', an empty file field, and a comment summarizing "
+    "what looks good and why the changes are acceptable.\n"
     "Do not add any text before or after the JSON array."
 )
 

--- a/test/test_gemini_client.py
+++ b/test/test_gemini_client.py
@@ -307,3 +307,136 @@ class TestHandleApiError:
             fail_fast_on_no_quota=False,
         )
         assert result is False
+
+
+# ---------------------------------------------------------------------------
+# _process_single_chunk — chunked API call config
+# ---------------------------------------------------------------------------
+
+
+class TestProcessSingleChunkConfig:
+    """Tests for config plumbing in _process_single_chunk and _process_chunks."""
+
+    def test_process_single_chunk_receives_llm_config(self, mocker):
+        """R3/R4: _process_single_chunk accepts and passes config to API call."""
+        mock_tracker = MagicMock()
+        mock_tracker.has_all_quotas_set_to_zero.return_value = False
+        mocker.patch("src.llm.gemini_client.QuotaTracker.from_env", return_value=mock_tracker)
+
+        client = MagicMock()
+        gc = GeminiClient(client)
+        mocker.patch.object(gc, "get_context_limit", return_value=1_000_000)
+        mocker.patch("src.llm.gemini_client.calculate_char_budget", return_value=10)
+
+        llm_config = MagicMock()
+        llm_config.system_instruction = "You are a code reviewer."
+        llm_config.temperature = 0.1
+        llm_config.top_p = 0.95
+        llm_config.max_output_tokens = 8192
+        llm_config.model = "gemini-2.5-flash"
+
+        response = MagicMock()
+        response.text = "review output"
+        client.models.generate_content.return_value = response
+
+        # This call should work once the llm_config param is added
+        result = gc._process_single_chunk(
+            model="gemini-2.5-flash",
+            idx=1,
+            total=1,
+            chunked_diff="some diff",
+            comments_text="",
+            max_attempts=2,
+            initial_wait=0.01,
+            max_wait=0.1,
+            min_request_interval=0.0,
+            fail_fast_on_no_quota=False,
+            tracker=mock_tracker,
+            llm_config=llm_config,
+        )
+        assert result == "review output"
+
+        # Verify the API call included config with response_mime_type and system_instruction
+        call_kwargs = client.models.generate_content.call_args.kwargs
+        assert "config" in call_kwargs, "API call must include config"
+        config = call_kwargs["config"]
+        assert config.response_mime_type == "application/json"
+        assert config.system_instruction == "You are a code reviewer."
+
+    def test_process_chunks_forwards_llm_config(self, mocker):
+        """R5: _process_chunks forwards llm_config to _process_single_chunk."""
+        mock_tracker = MagicMock()
+        mock_tracker.has_all_quotas_set_to_zero.return_value = False
+        mocker.patch("src.llm.gemini_client.QuotaTracker.from_env", return_value=mock_tracker)
+        mocker.patch("src.llm.gemini_client.calculate_char_budget", return_value=10)
+
+        client = MagicMock()
+        gc = GeminiClient(client)
+        mocker.patch.object(gc, "get_context_limit", return_value=1_000_000)
+
+        llm_config = MagicMock()
+        llm_config.system_instruction = "Review prompt"
+        llm_config.temperature = 0.1
+        llm_config.top_p = 0.95
+        llm_config.max_output_tokens = 8192
+        llm_config.model = "gemini-2.5-flash"
+
+        response = MagicMock()
+        response.text = "chunk result"
+        client.models.generate_content.return_value = response
+
+        # Spy on _process_single_chunk to verify it receives llm_config
+        spy = mocker.spy(gc, "_process_single_chunk")
+
+        gc._process_chunks(
+            model="gemini-2.5-flash",
+            chunked_diff_list=["chunk1", "chunk2"],
+            llm_config=llm_config,
+            comments_text="",
+        )
+
+        # Each call to _process_single_chunk should include llm_config
+        for call_args in spy.call_args_list:
+            assert "llm_config" in call_args.kwargs
+            assert call_args.kwargs["llm_config"] is llm_config
+
+    def test_generate_content_receives_config_with_system_instruction(self, mocker):
+        """R3/R4: SDK generate_content receives config with response_mime_type and system_instruction."""
+        mock_tracker = MagicMock()
+        mock_tracker.has_all_quotas_set_to_zero.return_value = False
+        mocker.patch("src.llm.gemini_client.QuotaTracker.from_env", return_value=mock_tracker)
+
+        client = MagicMock()
+        gc = GeminiClient(client)
+        mocker.patch.object(gc, "get_context_limit", return_value=1_000_000)
+        mocker.patch("src.llm.gemini_client.calculate_char_budget", return_value=10)
+
+        llm_config = MagicMock()
+        llm_config.system_instruction = "You are an expert code reviewer."
+
+        response = MagicMock()
+        response.text = "review text"
+        client.models.generate_content.return_value = response
+
+        gc._process_single_chunk(
+            model="gemini-2.5-flash",
+            idx=1,
+            total=1,
+            chunked_diff="diff content",
+            comments_text="",
+            max_attempts=2,
+            initial_wait=0.01,
+            max_wait=0.1,
+            min_request_interval=0.0,
+            fail_fast_on_no_quota=False,
+            tracker=mock_tracker,
+            llm_config=llm_config,
+        )
+
+        call_args = client.models.generate_content.call_args
+        assert call_args is not None
+        kwargs = call_args.kwargs
+        assert "config" in kwargs
+        config = kwargs["config"]
+        assert config.response_mime_type == "application/json"
+        assert config.system_instruction == "You are an expert code reviewer."

--- a/test/test_review_parser.py
+++ b/test/test_review_parser.py
@@ -349,8 +349,9 @@ class TestReviewSystemPrompt:
     def test_forbids_markdown(self):
         assert "Do not include any markdown" in REVIEW_SYSTEM_PROMPT
 
-    def test_mentions_empty_array(self):
-        assert "[]" in REVIEW_SYSTEM_PROMPT
+    def test_no_longer_mentions_empty_array(self):
+        """R2: Prompt MUST NOT contain any [] empty-output instruction."""
+        assert "[]" not in REVIEW_SYSTEM_PROMPT
 
     def test_suggestion_must_be_code_not_prose_or_diff(self):
         assert "exact replacement code" in REVIEW_SYSTEM_PROMPT


### PR DESCRIPTION
## Summary

- Fix: reviewer was posting `[]` as the PR comment when the model returned no items
- Root cause #1: `REVIEW_SYSTEM_PROMPT` explicitly told the model "If you have no comments, return an empty JSON array: []" — small models took the easy path on large diffs
- Root cause #2: `_process_single_chunk` had a regression that omitted `config` from the API call, breaking `response_mime_type` and `system_instruction` for chunked diffs

## Changes

| File | Change |
|------|--------|
| `src/review_parser.py` | Replace `[]` escape hatch with positive-summary instruction |
| `src/llm/gemini_client.py` | Restore `llm_config` plumbing in `_process_single_chunk` |
| `test/test_review_parser.py` | Update prompt test to assert absence of `[]` |
| `test/test_gemini_client.py` | Add `TestProcessSingleChunkConfig` (3 tests) |

## Test Plan

- [x] `pytest test/ -v` — 323/326 pass (3 pre-existing env var failures)
- [x] New tests specifically verify chunk config is forwarded with JSON mode

Closes #51