### PR TITLE
fix(review): localize review summary to English (was showing Spanish strings)

### DIFF
--- a/src/review_formatter.py
+++ b/src/review_formatter.py
@@ -131,8 +131,8 @@ def build_review_summary(
         if diff_stats:
             a, d = diff_stats.get("additions", 0), diff_stats.get("deletions", 0)
             f = diff_stats.get("files", 0)
-            return f"📋 Review: +{a} / -{d} líneas, {f} archivos\n✅ No se encontraron issues."
-        return "✅ No se encontraron issues."
+            return f"📋 Review: +{a} / -{d} lines, {f} files\n✅ No issues found."
+        return "✅ No issues found."
 
     # Count by severity
     counts: dict[str, int] = {}
@@ -152,7 +152,7 @@ def build_review_summary(
     if diff_stats:
         a, d = diff_stats.get("additions", 0), diff_stats.get("deletions", 0)
         f = diff_stats.get("files", 0)
-        lines.append(f"📋 Review: +{a} / -{d} líneas, {f} archivos")
+        lines.append(f"📋 Review: +{a} / -{d} lines, {f} files")
     else:
         lines.append("📋 Review")
 

--- a/test/test_review_formatter.py
+++ b/test/test_review_formatter.py
@@ -73,7 +73,7 @@ class TestBuildReviewSummary:
         result = build_review_summary(items, {"additions": 50, "deletions": 30, "files": 2})
         assert "📋 Review:" in result
         assert "+50 / -30" in result
-        assert "2 archivos" in result
+        assert "2 files" in result
         assert "🔴" in result
         assert "🟡" in result
         assert "🔵" in result
@@ -90,7 +90,7 @@ class TestBuildReviewSummary:
 
     def test_no_items(self):
         result = build_review_summary([], {"additions": 0, "deletions": 0, "files": 0})
-        assert "✅ No se encontraron issues" in result
+        assert "✅ No issues found" in result
 
     def test_single_critical(self):
         items = [{"severity": "critical", "comment": "Security hole"}]


### PR DESCRIPTION
## Summary

The review summary header was showing Spanish strings ("líneas", "archivos", "No se encontraron issues") instead of English. Changed to English to match the default locale for the rest of the output.

## Changes

| File | Change |
|------|--------|
| `src/review_formatter.py` | `líneas` → `lines`, `archivos` → `files`, `No se encontraron issues` → `No issues found` |
| `test/test_review_formatter.py` | Updated test assertions to match new English strings |

## Test Plan

- [x] `pytest test/test_review_formatter.py -v` — 14/14 pass